### PR TITLE
[Feat] 회원가입 API 수정사항 반영 및 소환사명 API 연동

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,15 +1,8 @@
+import { getAccessToken } from "@/utils/storage";
 import axios, { InternalAxiosRequestConfig, AxiosResponse, AxiosInstance } from "axios";
 
 export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 export const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL;
-
-/* 토큰을 가져오는 함수 */
-export const getToken = () => {
-  if (typeof window !== 'undefined') {
-    return localStorage.getItem('access_token');
-  }
-  return null;
-};
 
 /* Axios 인스턴스 생성 */
 const Axios: AxiosInstance = axios.create({
@@ -24,14 +17,14 @@ export const AuthAxios: AxiosInstance = axios.create({
   baseURL: BASE_URL,
   headers: {
     'Content-Type': 'application/json;charset=UTF-8',
-    Authorization: `Bearer ${getToken()}`,
+    Authorization: `Bearer ${getAccessToken()}`,
   },
 });
 
 /* 요청 인터셉터 */
 Axios.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
-    const token = getToken();
+    const token = getAccessToken();
     if (token) {
       config.headers['Authorization'] = `Bearer ${token}`;
     }

--- a/src/api/join.ts
+++ b/src/api/join.ts
@@ -3,6 +3,8 @@ import Axios from ".";
 interface joinProps {
     email: string;
     password: string;
+    gameName: string;
+    tag: string;
 }
 
 export const sendEmail= async ({ email }: { email: string }) => {
@@ -30,13 +32,27 @@ export const sendAuth= async ({ email, code }: { email: string, code: string }) 
   }
 };
 
+export const checkRiot = async ({ gameName, tag }: { gameName: string, tag: string }) => {
+  const endpoint = '/v1/member/riot';
+  try {
+    const response = await Axios.post(endpoint, { gameName, tag });
+    console.log("Riot 계정 확인 성공:", response);
+    return response.data;
+  } catch (error) {
+    console.error("Riot 계정 확인 실패:", error);
+    throw error;
+  }
+};
+
 export const joinMember = async ({
     email,
     password,
+    gameName,
+    tag
   }: joinProps) => {
     try {
       const response = await Axios.post('/v1/member/join', {
-        email, password
+        email, password, gameName, tag
       });
       console.log('회원가입 성공:', response.data);
       return response.data;

--- a/src/api/refreshToken.ts
+++ b/src/api/refreshToken.ts
@@ -1,0 +1,53 @@
+import axios from "axios";
+import Axios, { AuthAxios } from ".";
+import { LOGIN } from "@/constants/messages";
+
+const reissueToken = async () => {
+  const endpoint = '/v1/member/refresh';
+  try {
+    const response = await Axios.post(endpoint, { refreshToken: localStorage.getItem('refreshToken') });
+    console.log("accessToken 재발급 성공:", response);
+    return response.data;
+  } catch (error) {
+    console.error("accessToken 재발급 실패:", error);
+    throw error;
+  }
+};
+
+/* AuthAxios에 interceptor 적용 */
+AuthAxios.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    const {
+      config,
+      response: { status },
+    } = error;
+    
+    /* 토큰이 만료 시*/
+    if (status === 401) {
+      if (error.response.data.message === 'Unauthorized') {
+        const originRequest = config;
+        const response = await reissueToken();
+        // refreshToken 요청 성공
+        if (response.status === 200) {
+          const newAccessToken = response.data.token;
+          localStorage.setItem('accessToken', response.data.token);
+          localStorage.setItem('refreshToken', response.data.refreshToken);
+          axios.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
+          // 진행중이던 요청 이어서
+          originRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+          return axios(originRequest);
+        // refreshToken 요청 실패 (refreshToken도 만료되었을때 = 재로그인 안내)
+        } else if (response.status === 404) {
+          alert(LOGIN.MESSAGE.EXPIRED);
+          window.location.replace('/');
+        } else {
+          alert(LOGIN.MESSAGE.ETC);
+        }
+      }
+    }
+    return Promise.reject(error);
+  },
+);

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -14,7 +14,10 @@ import PostBoard from "@/components/createBoard/PostBoard";
 import ChatButton from "@/components/common/ChatButton";
 import { RootState } from "@/redux/store";
 import { useDispatch, useSelector } from "react-redux";
-import { setClosePostingModal, setOpenPostingModal } from "@/redux/slices/modalSlice";
+import {
+  setClosePostingModal,
+  setOpenPostingModal,
+} from "@/redux/slices/modalSlice";
 
 const DROP_DATA1 = [
   { id: 1, value: "솔로1" },
@@ -161,8 +164,10 @@ const BoardPage = () => {
   const dropdownRef2 = useRef<HTMLDivElement>(null);
 
   const dispatch = useDispatch();
-  
-  const isPostingModal = useSelector((state: RootState) => state.modal.postingModal);
+
+  const isPostingModal = useSelector(
+    (state: RootState) => state.modal.postingModal
+  );
 
   const handleFirstDropValue = (value: string) => {
     console.log(value);
@@ -194,7 +199,7 @@ const BoardPage = () => {
 
   const handleWritingClose = () => {
     dispatch(setClosePostingModal());
-    dispatchEvent
+    dispatchEvent;
   };
 
   const handleDropdownClickOutside1 = (event: MouseEvent) => {
@@ -320,6 +325,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const BoardContent = styled.div`

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import ChatButton from "@/components/common/ChatButton";
 import GraphicBox from "@/components/match/GraphicBox";
@@ -7,83 +7,82 @@ import Image from "next/image";
 import styled from "styled-components";
 
 const HomePage = () => {
-
-    return (
-        <Wrapper>
-            <HomeContent>
-                <Header>
-                    <Image
-                        src='/assets/icons/logo_m.svg'
-                        width={371}
-                        height={117}
-                        priority
-                        alt='logo' />
-                    <SubTitle>겜구 커뮤니티에 오신 것을 환영합니다.</SubTitle>
-                </Header>
-                <Main>
-                    {MATCH_PAGE_DATA.map((box) => {
-                        return (
-                            <GraphicBox
-                                key={box.id}
-                                pathname={box.pathname}
-                                height={box.height}
-                                top={box.top}
-                                left={box.left}
-                            >
-                                {box.title}
-                            </GraphicBox>
-
-                        )
-                    })}
-                </Main>
-                <Footer>
-                    <ChatBoxContent>
-                        <ChatButton count={3} />
-                    </ChatBoxContent>
-                </Footer>
-            </HomeContent>
-        </Wrapper>
-    )
+  return (
+    <Wrapper>
+      <HomeContent>
+        <Header>
+          <Image
+            src="/assets/icons/logo_m.svg"
+            width={371}
+            height={117}
+            priority
+            alt="logo"
+          />
+          <SubTitle>겜구 커뮤니티에 오신 것을 환영합니다.</SubTitle>
+        </Header>
+        <Main>
+          {MATCH_PAGE_DATA.map((box) => {
+            return (
+              <GraphicBox
+                key={box.id}
+                pathname={box.pathname}
+                height={box.height}
+                top={box.top}
+                left={box.left}
+              >
+                {box.title}
+              </GraphicBox>
+            );
+          })}
+        </Main>
+        <Footer>
+          <ChatBoxContent>
+            <ChatButton count={3} />
+          </ChatBoxContent>
+        </Footer>
+      </HomeContent>
+    </Wrapper>
+  );
 };
 
 export default HomePage;
 
 const Wrapper = styled.div`
-    width: 100%;
-    display: flex;
-    justify-content: center;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding-top: 140px;
 `;
 
 const HomeContent = styled.div`
-    max-width: 1440px;
-    width: 100%;
-    padding: 0 80px;
+  max-width: 1440px;
+  width: 100%;
+  padding: 0 80px;
 `;
 
 const Header = styled.header`
-    display: flex;
-    flex-direction: column;
-    align-items: start;
-    margin-bottom:52px;
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  margin-bottom: 52px;
 `;
 const SubTitle = styled.div`
-    ${(props) => props.theme.fonts.regular25};
-    color:#44515C;
+  ${(props) => props.theme.fonts.regular25};
+  color: #44515c;
 `;
 
 const Main = styled.main`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    row-gap:30px;
-    margin-bottom:37px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  row-gap: 30px;
+  margin-bottom: 37px;
 `;
 const Footer = styled.footer`
-    display: flex;
-    margin-bottom:78px;
+  display: flex;
+  margin-bottom: 78px;
 `;
 
 const ChatBoxContent = styled.div`
-    margin-left: auto;
+  margin-left: auto;
 `;
-

--- a/src/app/join/email/page.tsx
+++ b/src/app/join/email/page.tsx
@@ -53,7 +53,7 @@ const Email = () => {
     try {
       await sendEmail({ email });
       setAuthCode("");
-      setAuthCodeValid(false);
+      setAuthCodeValid(undefined);
       dispatch(updateEmailAuth(""));
       dispatch(updateAuthStatus(false));
       setIsSend(true);
@@ -100,6 +100,8 @@ const Email = () => {
             setAuthCode(value);
             if (value.length === 5) {
               setAuthCodeValid(true);
+            } else if (value.length === 0) {
+              setAuthCodeValid(undefined);
             } else {
               setAuthCodeValid(false);
             }

--- a/src/app/join/email/page.tsx
+++ b/src/app/join/email/page.tsx
@@ -91,9 +91,8 @@ const Email = () => {
         }}
         placeholder="이메일 주소"
         isValid={emailValid}
-        // disabled={isSend}
       />
-      {isSend && (
+      {(isSend || authCodeRedux) && (
         <Input
           inputType="input"
           value={authCode}
@@ -109,7 +108,7 @@ const Email = () => {
           isValid={authCodeValid}
         />
       )}
-      {isSend ? (
+      {isSend || authCodeRedux ? (
         <Button
           buttonType="primary"
           text="인증 완료"
@@ -120,8 +119,11 @@ const Email = () => {
           buttonType="primary"
           text="인증코드 전송"
           onClick={handleSendEmail}
-          disabled={!authCodeRedux || !emailValid}
+          disabled={!emailValid}
         />
+      )}
+      {isSend && (
+        <ReButton onClick={handleSendEmail}>인증 코드 재전송</ReButton>
       )}
     </Div>
   );
@@ -139,4 +141,12 @@ const Div = styled.div`
 const Label = styled.div`
   color: ${theme.colors.gray700};
   ${(props) => props.theme.fonts.regular25};
+`;
+
+const ReButton = styled.button`
+  color: ${theme.colors.purple100};
+  ${(props) => props.theme.fonts.medium16};
+  text-decoration-line: underline;
+  text-align: left;
+  margin-top: 10px;
 `;

--- a/src/app/join/layout.tsx
+++ b/src/app/join/layout.tsx
@@ -30,8 +30,10 @@ export default Layout;
 
 const Container = styled.div`
   width: 100%;
+  height: 100vh;
   display: flex;
   justify-content: center;
+  align-items: center;
 `;
 
 const Box = styled.div`
@@ -50,8 +52,8 @@ const Title = styled.div`
 
 const Content = styled.div`
   width: 100%;
+  margin-top: 100px;
   height: 500px;
   display: flex;
   justify-content: flex-start;
-  align-items: center;
 `;

--- a/src/app/join/password/page.tsx
+++ b/src/app/join/password/page.tsx
@@ -3,10 +3,11 @@
 import Button from "@/components/common/Button";
 import Input from "@/components/common/Input";
 import { updatePassword } from "@/redux/slices/signInSlice";
+import { RootState } from "@/redux/store";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { useDispatch } from "react-redux";
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 
 interface StyledValid {
@@ -24,6 +25,15 @@ const Password = () => {
   const [repasswordValid, setRepasswordValid] = useState<boolean | undefined>(
     undefined
   );
+
+  const passwordRedux = useSelector(
+    (state: RootState) => state.signIn.password
+  );
+
+  /* redux 업데이트 */
+  useEffect(() => {
+    setPassword(passwordRedux);
+  }, [passwordRedux]);
 
   const passwordRegEx =
     /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;

--- a/src/app/join/summoner/page.tsx
+++ b/src/app/join/summoner/page.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import { joinMember } from "@/api/join";
+import { checkRiot, joinMember } from "@/api/join";
 import Button from "@/components/common/Button";
 import Input from "@/components/common/Input";
 import { RootState } from "@/redux/store";
+import { theme } from "@/styles/theme";
+import { AxiosError } from "axios";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
+
+interface RiotErrorResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+}
 
 const Summoner = () => {
   const router = useRouter();
@@ -17,16 +25,84 @@ const Summoner = () => {
   const email = useSelector((state: RootState) => state.signIn.email);
   const password = useSelector((state: RootState) => state.signIn.password);
 
+  const [isCheckRiot, setIsCheckRiot] = useState<boolean | undefined>(
+    undefined
+  );
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const summonerNameRedux = useSelector(
+    (state: RootState) => state.signIn.summonerName
+  );
+  const summonerTagRedux = useSelector(
+    (state: RootState) => state.signIn.summonerTag
+  );
+
+  /* redux 업데이트 */
+  useEffect(() => {
+    setName(summonerNameRedux);
+    setTag(summonerTagRedux);
+  }, [summonerNameRedux, summonerTagRedux]);
+
+  /* input focus out 시 소환사명 조회 */
+  const handleCheckSummoner = async () => {
+    console.log("소환사명 조회(onBlur)");
+    try {
+      await checkRiot({ gameName: name, tag });
+      setIsCheckRiot(true);
+      setErrorMsg("");
+    } catch (err) {
+      const error = err as AxiosError<RiotErrorResponse>;
+      setIsCheckRiot(false);
+      setErrorMsg(
+        error.response?.data?.message || "소환사명 인증에 실패했습니다."
+      );
+    }
+  };
+
+  /* input 변경 시마다 소환사명 조회 */
+  // useEffect(() => {
+  //   const checkSummoner = async () => {
+  //     try {
+  //       await checkRiot({ gameName: name, tag });
+  //       setIsCheckRiot(true);
+  //     } catch (error) {
+  //       setIsCheckRiot(false);
+  //     }
+  //   };
+
+  //   if (name !== "" && tag !== "") {
+  //     checkSummoner();
+  //     console.log("소환사명 조회(useEffect)");
+  //   }
+  // }, [name, tag]);
+
   const handleSendJoin = async () => {
+    console.log(email, password);
     if (!email || !password) {
-      console.log("이메일과 비밀번호를 입력해주세요.");
+      setErrorMsg("이메일과 비밀번호를 다시 입력해주세요.");
       return;
     }
 
-    try {
-      await joinMember({ email, password });
-      router.push("/");
-    } catch (error) {}
+    if (isCheckRiot) {
+      try {
+        await joinMember({
+          email,
+          password,
+          gameName: name,
+          tag,
+        });
+        router.push("/");
+      } catch (err) {
+        const error = err as AxiosError<RiotErrorResponse>;
+        console.error(error.response?.data?.message);
+        setErrorMsg(
+          error.response?.data?.message ||
+            "회원가입에 실패했습니다. 다시 시도해주세요."
+        );
+      }
+    } else {
+      setErrorMsg("소환사명을 인증해주세요.");
+    }
   };
 
   return (
@@ -39,17 +115,22 @@ const Summoner = () => {
           onChange={(value) => {
             setName(value);
           }}
+          onBlur={handleCheckSummoner}
           placeholder="소환사명"
+          isValid={isCheckRiot}
         />
         <Input
           inputType="input"
           value={tag}
+          onBlur={handleCheckSummoner}
           onChange={(value) => {
             setTag(value);
           }}
           placeholder="소환사 태그 (예시 : #KR1)"
+          isValid={isCheckRiot}
         />
       </Row>
+      <Error>{errorMsg}</Error>
       <Button
         buttonType="primary"
         text="회원가입 완료"
@@ -77,4 +158,10 @@ const Row = styled.div`
   width: 100%;
   display: flex;
   gap: 15px;
+`;
+
+const Error = styled.div`
+  height: 15px;
+  color: ${theme.colors.error100};
+  ${(props) => props.theme.fonts.regular12}
 `;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import StyledComponentsRegistry from "@/libs/registry";
 import { Provider } from "react-redux";
 import { useRef } from "react";
 import { AppStore, store } from "@/redux/store";
+import { usePathname } from "next/navigation";
 
 export default function RootLayout({
   children,
@@ -17,9 +18,12 @@ export default function RootLayout({
 }>) {
   const storeRef = useRef<AppStore>();
   if (!storeRef.current) {
-    // Create the store instance the first time this renders
     storeRef.current = store();
   }
+
+  const pathname = usePathname();
+  const isHeader = !(pathname === "/" || pathname.includes("/join"));
+
   return (
     <html>
       <head>
@@ -31,7 +35,7 @@ export default function RootLayout({
           <GlobalStyles />
           <ThemeProvider theme={theme}>
             <Provider store={storeRef.current}>
-              <Header />
+              {isHeader && <Header />}
               {children}
             </Provider>
           </ThemeProvider>

--- a/src/app/match/game-mode/page.tsx
+++ b/src/app/match/game-mode/page.tsx
@@ -64,6 +64,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MatchContent = styled.div`

--- a/src/app/match/page.tsx
+++ b/src/app/match/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import styled from "styled-components";
 import ChatButton from "@/components/common/ChatButton";
@@ -6,7 +6,6 @@ import GraphicBox from "@/components/match/GraphicBox";
 import { MATCH_TYPE_PAGE_DATA } from "@/data/match";
 
 const MatchTypePage = () => {
-
   return (
     <Wrapper>
       <MatchContent>
@@ -16,20 +15,19 @@ const MatchTypePage = () => {
         <Main>
           {MATCH_TYPE_PAGE_DATA.map((box) => {
             return (
-              <BoxWrapper
-                key={box.id}
-              >
+              <BoxWrapper key={box.id}>
                 <GraphicBox
                   type={box.type}
                   pathname={box.pathname}
                   width={box.width}
                   height={box.height}
                   top={box.top}
-                  left={box.left}>
+                  left={box.left}
+                >
                   {box.title}
                 </GraphicBox>
               </BoxWrapper>
-            )
+            );
           })}
         </Main>
         <Footer>
@@ -39,7 +37,7 @@ const MatchTypePage = () => {
         </Footer>
       </MatchContent>
     </Wrapper>
-  )
+  );
 };
 
 export default MatchTypePage;
@@ -48,13 +46,14 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
-`
+  padding-top: 140px;
+`;
 
 const MatchContent = styled.div`
   max-width: 1440px;
-  width: 100%;;
+  width: 100%;
   padding: 0 80px;
-`
+`;
 
 const Header = styled.header`
   display: flex;
@@ -62,29 +61,29 @@ const Header = styled.header`
   align-items: start;
   width: 100%;
   margin-bottom: 32px;
-`
+`;
 
 const Title = styled.h1`
   ${(props) => props.theme.fonts.bold32};
-  color:#393939;
-`
+  color: #393939;
+`;
 
 const Main = styled.main`
   display: flex;
   align-items: center;
   width: 100%;
-  gap:27px;
-  margin-bottom:37px;
-`
+  gap: 27px;
+  margin-bottom: 37px;
+`;
 
 const BoxWrapper = styled.div`
   display: contents;
-`
+`;
 
 const Footer = styled.footer`
   display: flex;
-`
+`;
 
 const ChatBoxContent = styled.div`
   margin-left: auto;
-`
+`;

--- a/src/app/match/profile/page.tsx
+++ b/src/app/match/profile/page.tsx
@@ -75,6 +75,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MatchContent = styled.div`

--- a/src/app/matching/complete/page.tsx
+++ b/src/app/matching/complete/page.tsx
@@ -36,6 +36,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MatchContent = styled.div`

--- a/src/app/matching/progress/page.tsx
+++ b/src/app/matching/progress/page.tsx
@@ -86,6 +86,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MatchContent = styled.div`

--- a/src/app/mypage/alert/page.tsx
+++ b/src/app/mypage/alert/page.tsx
@@ -92,6 +92,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MyAlertContent = styled.div`

--- a/src/app/mypage/blocked/page.tsx
+++ b/src/app/mypage/blocked/page.tsx
@@ -59,6 +59,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MyBlockedContent = styled.div`

--- a/src/app/mypage/help/page.tsx
+++ b/src/app/mypage/help/page.tsx
@@ -21,6 +21,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MyHelpContent = styled.div`

--- a/src/app/mypage/post/page.tsx
+++ b/src/app/mypage/post/page.tsx
@@ -41,6 +41,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MyPostContent = styled.div`

--- a/src/app/mypage/profile/page.tsx
+++ b/src/app/mypage/profile/page.tsx
@@ -112,6 +112,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MyProfileContent = styled.div`

--- a/src/app/mypage/review/page.tsx
+++ b/src/app/mypage/review/page.tsx
@@ -128,6 +128,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MyReviewContent = styled.div`

--- a/src/app/mypage/service/page.tsx
+++ b/src/app/mypage/service/page.tsx
@@ -21,6 +21,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MyServiceContent = styled.div`

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import Checkbox from "@/components/common/Checkbox";
 import Input from "@/components/common/Input";
 import { emailRegEx } from "@/constants/regEx";
 import { theme } from "@/styles/theme";
+import { setToken } from "@/utils/storage";
 import { AxiosError } from "axios";
 import Image from "next/image";
 import Link from "next/link";
@@ -49,6 +50,7 @@ const Login = () => {
       } else {
         sessionStorage.setItem("accessToken", accessToken);
       }
+      setToken(accessToken, refreshToken, autoLogin);
 
       router.push("/home");
     } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -159,9 +159,11 @@ export default Login;
 
 const Container = styled.div`
   width: 100%;
-  height: 100%;
+  height: 100vh;
   display: flex;
   justify-content: center;
+  align-items: center;
+  padding-top: 140px;
 `;
 
 const Box = styled.div`
@@ -170,9 +172,8 @@ const Box = styled.div`
   padding: 35px;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
-
-  margin-bottom: 140px;
 `;
 
 const Title = styled.div`

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -163,7 +163,6 @@ const Container = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  padding-top: 140px;
 `;
 
 const Box = styled.div`

--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -155,6 +155,7 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  padding-top: 140px;
 `;
 
 const MatchContent = styled.div`

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -166,7 +166,7 @@ const Menus = styled.div`
   gap: 25px;
 `;
 
-const Menu = styled(Link) <HeaderProps>`
+const Menu = styled(Link)<HeaderProps>`
   font-weight: ${({ selected }) => (selected ? "700" : "400")};
 `;
 

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -17,6 +17,7 @@ interface InputProps {
   errorMsg?: string;
   fontSize?: string;
   borderRadius?: string;
+  onBlur?: () => void;
 }
 
 const Input = (props: InputProps) => {
@@ -34,6 +35,7 @@ const Input = (props: InputProps) => {
     errorMsg = "사용불가",
     fontSize,
     borderRadius,
+    onBlur,
   } = props;
 
   const handleChange = (event: any) => {
@@ -54,6 +56,7 @@ const Input = (props: InputProps) => {
           placeholder={placeholder}
           $fontSize={fontSize || "regular20"}
           $borderRadius={borderRadius || "15px"}
+          onBlur={onBlur}
         />
       ) : (
         <Box>
@@ -67,6 +70,7 @@ const Input = (props: InputProps) => {
             disabled={disabled}
             borderRadius={borderRadius || "15px"}
             height={height}
+            onBlur={onBlur}
           />
           {isValid !== undefined && (
             <Valid>
@@ -113,15 +117,15 @@ const StyledInput = styled.input<InputProps>`
     isValid === undefined
       ? `1px solid #b5b5b5`
       : isValid === true
-        ? `1px solid ${theme.colors.purple300}`
-        : `1px solid ${theme.colors.error100}`};
+      ? `1px solid ${theme.colors.purple300}`
+      : `1px solid ${theme.colors.error100}`};
   color: ${theme.colors.black};
   ${(props) => props.theme.fonts.regular16}
 
   &:focus {
     outline: none;
     border: ${({ isValid }) =>
-    isValid === undefined && `1px solid ${theme.colors.purple300}`};
+      isValid === undefined && `1px solid ${theme.colors.purple300}`};
   }
 
   &:disabled {
@@ -133,11 +137,10 @@ const StyledInput = styled.input<InputProps>`
   }
 `;
 
-
 const StyledTextarea = styled.textarea<{
-  $height: string | undefined,
-  $borderRadius: string | undefined,
-  $fontSize: string | undefined
+  $height: string | undefined;
+  $borderRadius: string | undefined;
+  $fontSize: string | undefined;
 }>`
   width: 100%;
   padding: 11px 20px;
@@ -146,14 +149,9 @@ const StyledTextarea = styled.textarea<{
   border: 1px solid #b5b5b5;
   color: ${theme.colors.black};
   ${({ $height }) =>
-    $height
-      ? `${theme.fonts.regular18}`
-      : `${theme.fonts.regular20}`};
-  resize: none; 
-  min-height: ${({ $height }) =>
-    $height
-      ? $height
-      : '160px'};
+    $height ? `${theme.fonts.regular18}` : `${theme.fonts.regular20}`};
+  resize: none;
+  min-height: ${({ $height }) => ($height ? $height : "160px")};
   ${(props) =>
     props.$fontSize
       ? props.theme.fonts[props.$fontSize as keyof typeof props.theme.fonts]

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,0 +1,6 @@
+export const LOGIN = {
+    MESSAGE: {
+      EXPIRED: "세션이 만료되었습니다. 다시 로그인 해주세요.",
+      ETC: "문제가 발생했습니다. 다시 시도해주세요.",
+    },
+  };

--- a/src/redux/slices/signInSlice.ts
+++ b/src/redux/slices/signInSlice.ts
@@ -5,6 +5,8 @@ interface SignInState {
     emailAuth: string;
     password: string;
     authStatus: boolean;
+    summonerName: string;
+    summonerTag: string;
 };
 
 const initialState: SignInState = {
@@ -12,6 +14,8 @@ const initialState: SignInState = {
     emailAuth: '',
     password: '',
     authStatus: false,
+    summonerName: '',
+    summonerTag: '',
 };
 
 export const signInSlice = createSlice({
@@ -29,6 +33,10 @@ export const signInSlice = createSlice({
     },
     updateAuthStatus: (state, action: PayloadAction<boolean>) => {
       state.authStatus = action.payload;
+    },
+    updateSummoner: (state, action: PayloadAction<string>) => {
+      state.summonerName = action.payload;
+      state.summonerTag = action.payload;
     },
   },
 });

--- a/src/redux/thunks/postSignIn.ts
+++ b/src/redux/thunks/postSignIn.ts
@@ -7,6 +7,8 @@ import { AxiosError } from 'axios';
 interface SignInData {
   email: string;
   password: string;
+  gameName: string;
+  tag: string;
 }
 
 export const postSignIn = createAsyncThunk(
@@ -20,6 +22,8 @@ export const postSignIn = createAsyncThunk(
       const joinData = {
         email: signInState.email,
         password: signInState.password,
+        gameName: signInState.summonerName,
+        tag: signInState.summonerTag,
       };
       
       if (signInState.authStatus === true) {

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -12,7 +12,6 @@ body {
   width: 100%;
   font-family: "Pretendard";
   white-space: pre-line;
-  padding-top: 70px;
 }
 
 a {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,33 @@
+/* 토큰 저장 */
+export const setToken = (accessToken: string, refreshToken: string, autoLogin: boolean) => {
+    if (autoLogin) {
+        localStorage.setItem('accessToken', accessToken);
+        localStorage.setItem('refreshToken', refreshToken);
+    } else {
+        sessionStorage.setItem('accessToken', accessToken);
+        sessionStorage.setItem('refreshToken', refreshToken);
+    }
+};
+
+/* 토큰 사용 */
+export const getAccessToken = () => {
+    if (typeof window !== 'undefined') {
+        return localStorage.getItem('accessToken') || sessionStorage.getItem('accessToken');
+    }
+    return null;
+};
+
+export const getRefreshToken = () => {
+    if (typeof window !== 'undefined') {
+        return localStorage.getItem('refreshToken') || sessionStorage.getItem('refreshToken');
+    }
+    return null;
+};
+
+/* 토큰 제거 */
+export const clearTokens = () => {
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    sessionStorage.removeItem('accessToken');
+    sessionStorage.removeItem('refreshToken');
+};


### PR DESCRIPTION
## 연관 이슈

close #56

<br/>

## 📁 작업 내용
- Header 경로별 렌더링 설정 (저번 conflict 때 반영 내용이 내려간 거 같아 다시 추가했어요!)
- 로그인, 회원가입 scroll 없게 정중앙 배치
- 변경된 회원가입 API 연동
- 소환사명 조회 API 연동
- 토큰 재발급 API 연동

<br/>

## 🖥 구현 결과 (선택)
https://github.com/user-attachments/assets/dde6eb0f-bb98-481c-be2e-b12a9a6d8544

- 소환사명 확인 가능한 걸로 테스트 했고 회원가입 성공 확인했습니다!

<br/>

## ✔ 리뷰 요구사항
- redux 관련해서 잘 사용하고 있는지 확인하고 싶습니다. 회원가입 프로세스에서 리덕스로 상태를 저장해서 앞뒤 페이지로 이동했을 때에도 데이터가 날라가지않고 보존되게 했는데, 이게 로그인 화면에서 회원가입으로 넘어갈 때에도 적용이 되니 이상하게 느껴지더라구요. clear를 언제 시켜야 하는지.. 좋은 방식이 맞는지.. 궁금합니다.
- 이메일 인증 관련해서 시은님께 디자인 요청 드렸었는데 희경님 의견도 듣고 싶습니다! 이메일 인증할 때 이메일로 시작하기를한 뒤 (인증전송 버튼) 인증코드를 작성한 상태에서 이메일을 변경할 경우 어떤 UI가 나오는게 자연스러울지요? 그대로 가면 인증번호 재전송 버튼을 눌러야 하는데, 이메일이 변경되었으니 재전송이 맞나..? 싶고 이전 화면으로 돌아가자니 이메일 input에 실수로 입력값이 들어갔을 때 바로 화면 이전으로 돌아가면서 인증 과정을 다시 해야 한다는 불편함이 있을 것 같아서요! 월요일 회의 때까지 고민해보시고 의견 주시면 회의 때 말씀드릴 수 있을 것 같아요!
- 그리고 refreshToken으로 토큰 재발급 하는 부분도 처음 해본 부분이라 한번 확인 부탁드립니다! axios 인터셉터를 사용해서 AuthAxios가 요청될 때 토큰에 문제가 있을 경우 토큰 재발급 api를 호출하는 방식으로 해보았는데, 저렇게만 작성하면 적용이 된 것인지 정확하게 모르겠어서ㅎㅎ 이렇게 요청 남깁니다~!

<br/>

## 📁 기타 사항
- GlobalStyle에 있던 padding은 빼고, 각 페이지별 Wrapper에 padding 넣었습니다. (Header 존재 여부에 따라 달라지는 스타일 반영 위해)
  - Wrapper 컴포넌트는 스타일이 중복으로 사용되어서 나중에 별도의 styled-components로 빼서 정의하려고 합니다! 혹시 비슷하게 페이지별 중복되어서 많이 쓰이는 스타일 있다면 마찬가지로 따로 정의해두고 import 해서 사용하면 좋을 것 같아요!
- 혹시 더미데이터 외에 상수로 관리할 수 있는 것들은 const 폴더에 추가해주세요! (메세지 등)
- 토큰 관련 함수 utils>storage.ts에 넣어두었습니다!

<br/>
