### PR TITLE
[Fix] 실시간 매칭 에러 수정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,7 +27,7 @@ const nextConfig = {
 
     return config;
   },
-  reactStrictMode: true,
+  reactStrictMode: false,
   compiler: {
     styledComponents: true,
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import styled, { ThemeProvider } from "styled-components";
 import { theme } from "@/styles/theme";
 import Header from "@/components/common/Header";
 import StyledComponentsRegistry from "@/libs/registry";
-import { Provider } from "react-redux";
+import { Provider, useSelector } from "react-redux";
 import { useEffect, useRef } from "react";
 import { AppStore, RootState, store } from "@/redux/store";
 import { usePathname } from "next/navigation";
@@ -18,7 +18,11 @@ import {
 } from "@/socket";
 import { HelmetProvider, Helmet } from "react-helmet-async";
 import Footer from "@/components/common/Footer";
-import { getAccessToken } from "@/utils/storage";
+import {
+  getAccessToken,
+  getIsCompleted,
+  setIsCompleted,
+} from "@/utils/storage";
 import { notify } from "@/hooks/notify";
 
 export default function RootLayout({
@@ -42,6 +46,7 @@ export default function RootLayout({
   );
 
   const accesssToken = getAccessToken(); // 로그인 유무 결정
+  const isCompleted = getIsCompleted();
 
   /* 로그인 이전 소켓 연결 */
   useEffect(() => {
@@ -53,7 +58,8 @@ export default function RootLayout({
   }, [accesssToken]);
 
   useEffect(() => {
-    if (
+    if (!(isCompleted === "true") || isCompleted === null) {
+    } else if (
       !pathname.includes("/matching/complete") &&
       previousPathname.current !== pathname &&
       previousPathname.current.includes("/matching")
@@ -64,6 +70,10 @@ export default function RootLayout({
         icon: "🚫",
         type: "error",
       });
+    }
+
+    if (pathname.includes("/") || pathname.includes("/match")) {
+      setIsCompleted("false");
     }
 
     // 이전 경로 업데이트

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,10 +11,15 @@ import { AppStore, RootState, store } from "@/redux/store";
 import { usePathname } from "next/navigation";
 import SocketConnection from "@/components/socket/SocketConnection";
 import { Toaster } from "react-hot-toast";
-import { connectSocket, disconnectSocket } from "@/socket";
+import {
+  connectSocket,
+  disconnectSocket,
+  sendMatchingQuitEvent,
+} from "@/socket";
 import { HelmetProvider, Helmet } from "react-helmet-async";
 import Footer from "@/components/common/Footer";
 import { getAccessToken } from "@/utils/storage";
+import { notify } from "@/hooks/notify";
 
 export default function RootLayout({
   children,
@@ -27,6 +32,7 @@ export default function RootLayout({
   }
 
   const pathname = usePathname();
+  const previousPathname = useRef(pathname);
   const isNotFoundPage = pathname === "/404" || pathname === "/not-found";
   const isHeader = !(
     isNotFoundPage ||
@@ -45,6 +51,24 @@ export default function RootLayout({
       disconnectSocket();
     }
   }, [accesssToken]);
+
+  useEffect(() => {
+    if (
+      !pathname.includes("/matching/complete") &&
+      previousPathname.current !== pathname &&
+      previousPathname.current.includes("/matching")
+    ) {
+      sendMatchingQuitEvent();
+      notify({
+        text: "화면 이탈로 매칭이 종료되었습니다.",
+        icon: "🚫",
+        type: "error",
+      });
+    }
+
+    // 이전 경로 업데이트
+    previousPathname.current = pathname;
+  }, [pathname]);
 
   return (
     <html>

--- a/src/app/match/profile/page.tsx
+++ b/src/app/match/profile/page.tsx
@@ -16,6 +16,7 @@ import ChatButton from "@/components/common/ChatButton";
 import { sendMatchingQuitEvent, socket } from "@/socket";
 import ConfirmModal from "@/components/common/ConfirmModal";
 import { theme } from "@/styles/theme";
+import useEventQueue from "@/hooks/useEventQueue";
 
 const ProfilePage = () => {
   const router = useRouter();
@@ -25,6 +26,7 @@ const ProfilePage = () => {
   const params = searchParams.get("type");
   const rank = searchParams.get("rank");
   const retry = searchParams.get("retry");
+  const { addEventToQueue } = useEventQueue(); // 이벤트 큐 사용
 
   /* 모달창 */
   const [isAlready, setIsAlready] = useState<boolean>(false);
@@ -110,7 +112,8 @@ const ProfilePage = () => {
       /* 매칭 시작 이벤트 */
       socket.on("matching-started", (data) => {
         console.log("매칭 시작됨:", data);
-
+        // 라우터 이동 중이면 이벤트를 큐에 저장
+        addEventToQueue(data);
         const urlParams = new URLSearchParams({
           ...data.data,
           matchingType: params || "", // 기존 type 파라미터 추가
@@ -120,7 +123,7 @@ const ProfilePage = () => {
         if (retry) {
           urlParams.append("retry", "true");
         }
-        
+
         router.push(`/matching/progress?${urlParams.toString()}`);
       });
     } else {
@@ -145,7 +148,6 @@ const ProfilePage = () => {
             width="380px"
             text="매칭 시작하기"
             onClick={handleMatchStart}
-            disabled={matchInfo.gameStyleResponseDTOList.length === 0}
           />
         </Main>
         <Footer>

--- a/src/app/matching/complete/page.tsx
+++ b/src/app/matching/complete/page.tsx
@@ -16,7 +16,6 @@ import ChatLayout from "@/components/chat/ChatLayout";
 import { RootState } from "@/redux/store";
 import { useDispatch, useSelector } from "react-redux";
 import { openChatRoom, setChatRoomUuid } from "@/redux/slices/chatSlice";
-import useEventQueue from "@/hooks/useEventQueue";
 import { setComplete } from "@/redux/slices/matchingSlice";
 import { setIsCompleted } from "@/utils/storage";
 

--- a/src/app/matching/complete/page.tsx
+++ b/src/app/matching/complete/page.tsx
@@ -278,12 +278,16 @@ const Complete = () => {
             <SquareProfile user={userMe} />
             <Oppnent>
               <SquareProfile opponent={true} user={user} />
-              <Button
-                buttonType="secondary"
-                text="매칭 거절하기"
-                onClick={handleReject}
-              />
-              <Text>{timeLeft}초 뒤 자동으로 대화방이 생성됩니다.</Text>
+              {timeLeft > 0 && (
+                <>
+                  <Button
+                    buttonType="secondary"
+                    text="매칭 거절하기"
+                    onClick={handleReject}
+                  />
+                  <Text>{timeLeft}초 뒤 자동으로 대화방이 생성됩니다.</Text>
+                </>
+              )}
             </Oppnent>
           </Main>
           <Footer>

--- a/src/app/matching/complete/page.tsx
+++ b/src/app/matching/complete/page.tsx
@@ -269,7 +269,11 @@ const Complete = () => {
       {isChatRoomOpen && <ChatLayout apiType={1} />}
       <Wrapper>
         <MatchContent>
-          <HeaderTitle title="매칭 완료" sub="듀오 상대를 찾았어요!" />
+          <HeaderTitle
+            title="매칭 완료"
+            sub="듀오 상대를 찾았어요!"
+            isDoubleBack={true}
+          />
           <Main>
             <SquareProfile user={userMe} />
             <Oppnent>

--- a/src/app/matching/complete/page.tsx
+++ b/src/app/matching/complete/page.tsx
@@ -16,6 +16,7 @@ import ChatLayout from "@/components/chat/ChatLayout";
 import { RootState } from "@/redux/store";
 import { useDispatch, useSelector } from "react-redux";
 import { openChatRoom, setChatRoomUuid } from "@/redux/slices/chatSlice";
+import useEventQueue from "@/hooks/useEventQueue";
 
 interface User {
   memberId: number;
@@ -128,21 +129,17 @@ const Complete = () => {
   const secondaryTimerRef = useRef<NodeJS.Timeout | null>(null);
   const finalTimerRef = useRef<NodeJS.Timeout | null>(null);
 
+  // 매칭 상대 결정 & 매칭 완료에 따라 quit 여부 처리하기 (수정 필요)
   useEffect(() => {
     const handleBeforeUnload = () => {
       sendMatchingQuitEvent();
-    };
-
-    const handlePopState = () => {
-      sendMatchingQuitEvent();
-      return true;
     };
 
     // 페이지 이탈 및 새로고침 감지
     window.addEventListener("beforeunload", handleBeforeUnload);
 
     // 뒤로가기를 감지
-    window.addEventListener("popstate", handlePopState);
+    window.addEventListener("popstate", handleBeforeUnload);
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -4,406 +4,466 @@ import Image from "next/image";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Chat, DesignedSystemMessage, ChatMessageDto } from "@/interface/chat";
 import { useDispatch, useSelector } from "react-redux";
-import { setCloseMannerStatusModal, setOpenMannerStatusModal, setOpenReadingModal } from "@/redux/slices/modalSlice";
+import {
+  setCloseMannerStatusModal,
+  setOpenMannerStatusModal,
+  setOpenReadingModal,
+} from "@/redux/slices/modalSlice";
 import { RootState } from "@/redux/store";
 import ReadBoard from "../readBoard/ReadBoard";
 import { getChatList } from "@/api/chat";
 import useChatMessage from "@/hooks/useChatMessage";
-import dayjs from 'dayjs';
+import dayjs from "dayjs";
 import { setChatDateFormatter, setChatTimeFormatter } from "@/utils/custom";
 import { getProfileBgColor } from "@/utils/profile";
 import ConfirmModal from "../common/ConfirmModal";
 import { socket } from "@/socket";
 
 interface MessageListProps {
-    chatEnterData: Chat;
-    systemMessage: DesignedSystemMessage | undefined;
-    onMannerValuesGet: (memberId: number) => void;
-    onBadMannerValuesGet: (memberId: number) => void;
+  chatEnterData: Chat;
+  systemMessage: DesignedSystemMessage | undefined;
+  onMannerValuesGet: (memberId: number) => void;
+  onBadMannerValuesGet: (memberId: number) => void;
 }
 
 interface SystemMessageProps {
-    message: string;
-    onClick?: () => void;
+  message: string;
+  onClick?: () => void;
 }
 
 const MessageList = (props: MessageListProps) => {
-    const { chatEnterData, systemMessage, onMannerValuesGet, onBadMannerValuesGet } = props;
+  const {
+    chatEnterData,
+    systemMessage,
+    onMannerValuesGet,
+    onBadMannerValuesGet,
+  } = props;
 
-    const dispatch = useDispatch();
+  const dispatch = useDispatch();
 
-    const [messageList, setMessageList] = useState<ChatMessageDto[]>(chatEnterData?.chatMessageList.chatMessageDtoList || []);
-    const [isLoading, setIsLoading] = useState(false);
-    const [cursor, setCursor] = useState<number | null>(chatEnterData?.chatMessageList.has_next ? chatEnterData.chatMessageList.next_cursor : null);
-    const [hasMore, setHasMore] = useState<boolean>(chatEnterData?.chatMessageList.has_next);
-    const [isInitialLoading, setIsInitialLoading] = useState(true);
-    const [isBoardId, setIsBoardId] = useState(0);
-    const [isSystemMessageShown, setIsSystemMessageShown] = useState(false);
-    const [isUnregisterAlert, setIsUnregisterAlert] = useState(false);
-    const [isBlockedAlert, setIsBlockedAlert] = useState(false);
-    const [mannerSystemMessage, setMannerSystemMessage] = useState(false);
-    const [isFeedbackDateVisible, setIsFeedbackDateVisible] = useState(false);
-    const [isFeedbackDate, setIsFeedbackDate] = useState<string>("");
+  const [messageList, setMessageList] = useState<ChatMessageDto[]>(
+    chatEnterData?.chatMessageList.chatMessageDtoList || []
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [cursor, setCursor] = useState<number | null>(
+    chatEnterData?.chatMessageList.has_next
+      ? chatEnterData.chatMessageList.next_cursor
+      : null
+  );
+  const [hasMore, setHasMore] = useState<boolean>(
+    chatEnterData?.chatMessageList.has_next
+  );
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
+  const [isBoardId, setIsBoardId] = useState(0);
+  const [isSystemMessageShown, setIsSystemMessageShown] = useState(false);
+  const [isUnregisterAlert, setIsUnregisterAlert] = useState(false);
+  const [isBlockedAlert, setIsBlockedAlert] = useState(false);
+  const [mannerSystemMessage, setMannerSystemMessage] = useState(false);
+  const [isFeedbackDateVisible, setIsFeedbackDateVisible] = useState(false);
+  const [isFeedbackDate, setIsFeedbackDate] = useState<string>("");
 
-    const chatRef = useRef<HTMLDivElement>(null);
-    const isReadingModal = useSelector((state: RootState) => state.modal.readingModal);
-    const isFeedbackModalOpen = useSelector((state: RootState) => state.modal.isOpen);
+  const chatRef = useRef<HTMLDivElement>(null);
+  const isReadingModal = useSelector(
+    (state: RootState) => state.modal.readingModal
+  );
+  const isFeedbackModalOpen = useSelector(
+    (state: RootState) => state.modal.isOpen
+  );
 
-    const { newMessage } = useChatMessage();
+  const { newMessage } = useChatMessage();
 
-    /* 매너 시스템 소켓 이벤트 리스닝 */
-    useEffect(() => {
-        const handleMannerSystemMessage = () => {
-            setMannerSystemMessage(true);
-        };
-
-        if (socket) {
-            socket.on('manner-system-message', handleMannerSystemMessage);
-        }
-
-        return () => {
-            if (socket) {
-                socket.off('manner-system-message', handleMannerSystemMessage);
-            }
-        };
-    }, []);
-
-    /* 시스템 메시지 클릭 시 다음 스텝 */
-    const handlePostOpen = (boardId: number) => {
-        if (chatEnterData.blind || chatEnterData.blocked) {
-            setIsUnregisterAlert(true);
-            setIsBlockedAlert(true);
-        } else {
-            dispatch(setOpenReadingModal());
-            setIsBoardId(boardId);
-        }
+  /* 매너 시스템 소켓 이벤트 리스닝 */
+  useEffect(() => {
+    const handleMannerSystemMessage = () => {
+      setMannerSystemMessage(true);
     };
 
-    /* 게시글 이동 클릭시 탈퇴회원, 차단회원 알럿 3초후 사라짐 */
-    useEffect(() => {
-        let timer: any;
-        if (isUnregisterAlert || isBlockedAlert) {
-            timer = setTimeout(() => {
-                setIsUnregisterAlert(false);
-                setIsBlockedAlert(false);
-            }, 3000);
-        }
-        return () => clearTimeout(timer);
-    }, [isUnregisterAlert, isBlockedAlert]);
+    if (socket) {
+      socket.on("manner-system-message", handleMannerSystemMessage);
+    }
 
-    /* 새로운 메시지 전에 시스템 메시지 보여주기 */
-    useEffect(() => {
-        if (newMessage) {
-            setMessageList((prevMessages) => {
-                let updatedMessages = [...prevMessages];
-
-                if (systemMessage && !isSystemMessageShown) {
-                    // 기존 시스템 메시지와, 새로운 시스템 메시지 타입이 달라서, 타입 같게 변경
-                    const systemMessageAsChatMessage: ChatMessageDto = {
-                        ...systemMessage,
-                        createdAt: new Date().toISOString(),
-                        timestamp: new Date().getTime(),
-                    };
-                    updatedMessages.push(systemMessageAsChatMessage);
-                }
-
-                // 새로운 메시지 추가
-                updatedMessages.push(newMessage);
-
-                return updatedMessages;
-            });
-
-            if (!isSystemMessageShown) {
-                setIsSystemMessageShown(true);
-            }
-        }
-    }, [newMessage, systemMessage]);
-
-    /* 처음 채팅방 들어올 때 마지막 메시지로 스크롤 이동 */
-    useEffect(() => {
-        if (chatRef.current && isInitialLoading) {
-            const chatElement = chatRef.current;
-            chatElement.scrollTop = chatElement.scrollHeight;
-            setIsInitialLoading(false);
-        }
-    }, [chatRef, messageList, isInitialLoading]);
-
-    const handleScroll = useCallback(() => {
-        if (chatRef.current && !isInitialLoading) {
-            const { scrollTop } = chatRef.current;
-            if (scrollTop === 0 && hasMore && !isLoading) {
-                getMoreMessages();
-            }
-        }
-    }, [chatRef, hasMore, isLoading, isInitialLoading]);
-
-
-    useEffect(() => {
-        const chatElement = chatRef.current;
-        if (chatElement) {
-            chatElement.addEventListener('scroll', handleScroll);
-        }
-
-        return () => {
-            if (chatElement) {
-                chatElement.removeEventListener('scroll', handleScroll);
-            }
-        };
-    }, [chatRef, handleScroll]);
-
-    /* 새로운 메시지 입력 또는 새로운 메시지 입력 시 스크롤을 맨 아래로 이동시키는 함수 */
-    const scrollToBottom = useCallback(() => {
-        if (chatRef.current) {
-            chatRef.current.scrollTop = chatRef.current.scrollHeight;
-        }
-    }, [chatRef]);
-
-    useEffect(() => {
-        if (newMessage) {
-            setMessageList((prevMessages) => [...prevMessages, newMessage]);
-
-            requestAnimationFrame(() => {
-                scrollToBottom();
-            });
-        }
-    }, [newMessage, scrollToBottom]);
-
-    /* 남은 메시지 보여주기(페이징) */
-    const getMoreMessages = useCallback(async () => {
-        if (isLoading || !hasMore) return;
-
-        setIsLoading(true);
-        try {
-            const chatElement = chatRef.current;
-            if (!chatElement) return;
-
-            // 현재 스크롤 위치와 전체 높이 저장
-            const previousScrollTop = chatElement.scrollTop;
-            const previousScrollHeight = chatElement.scrollHeight;
-
-            const data = await getChatList(chatEnterData.uuid, cursor);
-            const { chatMessageDtoList, next_cursor, has_next } = data.result;
-
-            // 기존 메시지 목록에 새로운 메시지 추가
-            setMessageList((prevMessages) => [
-                ...chatMessageDtoList,
-                ...prevMessages
-            ]);
-
-            setCursor(next_cursor);
-            setHasMore(has_next);
-
-            requestAnimationFrame(() => {
-                // 새로운 메시지가 추가된 후의 스크롤 높이 차이 계산
-                const newScrollHeight = chatElement.scrollHeight;
-                const scrollDifference = newScrollHeight - previousScrollHeight;
-
-                // 스크롤 위치를 기존 위치에서 중간 지점으로 이동 (새로운 메시지가 들어올 때 자연스럽게 스크롤 이동하기 위해서)
-                chatElement.scrollTop = previousScrollTop + scrollDifference;
-            });
-        } catch (error) {
-            console.error(error);
-        } finally {
-            setIsLoading(false);
-        }
-    }, [isLoading, hasMore, cursor, chatEnterData]);
-
-    /* 채팅 날짜 표시 */
-    const handleDisplayDate = (messages: ChatMessageDto[], index: number): boolean => {
-        if (index === 0) return true;
-
-        const currentDate = dayjs(messages[index].createdAt).format('YYYY-M-D');
-        const previousDate = dayjs(messages[index - 1].createdAt).format('YYYY-M-D');
-
-        return currentDate !== previousDate;
+    return () => {
+      if (socket) {
+        socket.off("manner-system-message", handleMannerSystemMessage);
+      }
     };
+  }, []);
 
-    /* 프로필 이미지 표시 (상대방만 보여주기, 같은 시간에 온 경우 첫번째 메시지만 이미지 표시F) */
-    const handleDisplayProfileImage = (messages: ChatMessageDto[], index: number): boolean => {
-        if (index === 0) return true;
+  /* 시스템 메시지 클릭 시 다음 스텝 */
+  const handlePostOpen = (boardId: number) => {
+    if (chatEnterData.blind || chatEnterData.blocked) {
+      setIsUnregisterAlert(true);
+      setIsBlockedAlert(true);
+    } else {
+      dispatch(setOpenReadingModal());
+      setIsBoardId(boardId);
+    }
+  };
 
-        const currentSenderId = messages[index].senderId;
-        const previousSenderId = messages[index - 1].senderId;
+  /* 게시글 이동 클릭시 탈퇴회원, 차단회원 알럿 3초후 사라짐 */
+  useEffect(() => {
+    let timer: any;
+    if (isUnregisterAlert || isBlockedAlert) {
+      timer = setTimeout(() => {
+        setIsUnregisterAlert(false);
+        setIsBlockedAlert(false);
+      }, 3000);
+    }
+    return () => clearTimeout(timer);
+  }, [isUnregisterAlert, isBlockedAlert]);
 
-        const currentTime = dayjs(messages[index].createdAt).format('A hh:mm');
-        const previousTime = dayjs(messages[index - 1].createdAt).format('A hh:mm');
+  /* 새로운 메시지 전에 시스템 메시지 보여주기 */
+  useEffect(() => {
+    if (newMessage) {
+      setMessageList((prevMessages) => {
+        let updatedMessages = [...prevMessages];
 
-        // 보낸 사람이 다르거나, 시간이 다르면 프로필 이미지를 표시
-        if (currentSenderId !== previousSenderId || currentTime !== previousTime) {
-            return true;
+        if (systemMessage && !isSystemMessageShown) {
+          // 기존 시스템 메시지와, 새로운 시스템 메시지 타입이 달라서, 타입 같게 변경
+          const systemMessageAsChatMessage: ChatMessageDto = {
+            ...systemMessage,
+            createdAt: new Date().toISOString(),
+            timestamp: new Date().getTime(),
+          };
+          updatedMessages.push(systemMessageAsChatMessage);
         }
 
-        return false;
+        // 새로운 메시지 추가
+        // updatedMessages.push(newMessage);
+
+        return updatedMessages;
+      });
+
+      if (!isSystemMessageShown) {
+        setIsSystemMessageShown(true);
+      }
+    }
+  }, [newMessage, systemMessage]);
+
+  /* 처음 채팅방 들어올 때 마지막 메시지로 스크롤 이동 */
+  useEffect(() => {
+    if (chatRef.current && isInitialLoading) {
+      const chatElement = chatRef.current;
+      chatElement.scrollTop = chatElement.scrollHeight;
+      setIsInitialLoading(false);
+    }
+  }, [chatRef, messageList, isInitialLoading]);
+
+  const handleScroll = useCallback(() => {
+    if (chatRef.current && !isInitialLoading) {
+      const { scrollTop } = chatRef.current;
+      if (scrollTop === 0 && hasMore && !isLoading) {
+        getMoreMessages();
+      }
+    }
+  }, [chatRef, hasMore, isLoading, isInitialLoading]);
+
+  useEffect(() => {
+    const chatElement = chatRef.current;
+    if (chatElement) {
+      chatElement.addEventListener("scroll", handleScroll);
+    }
+
+    return () => {
+      if (chatElement) {
+        chatElement.removeEventListener("scroll", handleScroll);
+      }
     };
+  }, [chatRef, handleScroll]);
 
-    /* 메시지 시간 표시 (마지막 메시지에만 시간 표시, 상대방 메시지 중간에 오면 다시 표시) */
-    const handleDisplayTime = (messages: ChatMessageDto[], index: number): boolean => {
-        if (index === messages.length - 1) return true;
+  /* 새로운 메시지 입력 또는 새로운 메시지 입력 시 스크롤을 맨 아래로 이동시키는 함수 */
+  const scrollToBottom = useCallback(() => {
+    if (chatRef.current) {
+      chatRef.current.scrollTop = chatRef.current.scrollHeight;
+    }
+  }, [chatRef]);
 
-        const currentTime = dayjs(messages[index].createdAt).format('A hh:mm');
-        const nextTime = dayjs(messages[index + 1].createdAt).format('A hh:mm');
+  useEffect(() => {
+    if (newMessage) {
+      setMessageList((prevMessages) => [...prevMessages, newMessage]);
 
-        const isSameTime = currentTime === nextTime;
-        const isSameSender = messages[index].senderId === messages[index + 1].senderId;
+      requestAnimationFrame(() => {
+        scrollToBottom();
+      });
+    }
+    console.log("chatEnterData", chatEnterData);
+  }, [newMessage, scrollToBottom]);
 
-        // 시간이 같고, 보낸 사람도 같으면 마지막 메시지에만 시간 표시
-        if (isSameTime && isSameSender) {
-            return false;
-        }
+  /* 남은 메시지 보여주기(페이징) */
+  const getMoreMessages = useCallback(async () => {
+    if (isLoading || !hasMore) return;
 
-        return true;
-    };
+    setIsLoading(true);
+    try {
+      const chatElement = chatRef.current;
+      if (!chatElement) return;
 
-    /* 마지막 채팅을 보낸 후 1시간이 지난 시점에서 피드백 요청 표시 */
-    useEffect(() => {
-        const lastMessage = chatEnterData?.chatMessageList.chatMessageDtoList[chatEnterData.chatMessageList.chatMessageDtoList.length - 1];
-        const feedbackTimestamp = dayjs(lastMessage?.createdAt).add(1, 'hour');
-        const feedbackFullDate = dayjs(feedbackTimestamp).format('YYYY-MM-DDTHH:mm:ss');
+      // 현재 스크롤 위치와 전체 높이 저장
+      const previousScrollTop = chatElement.scrollTop;
+      const previousScrollHeight = chatElement.scrollHeight;
 
-        const feedbackDate = dayjs(feedbackTimestamp).format('YYYY-M-D');
-        const lastMessageDate = dayjs(lastMessage?.createdAt).format('YYYY-M-D');
+      const data = await getChatList(chatEnterData.uuid, cursor);
+      const { chatMessageDtoList, next_cursor, has_next } = data.result;
 
-        setIsFeedbackDate(feedbackFullDate);
+      // 기존 메시지 목록에 새로운 메시지 추가
+      setMessageList((prevMessages) => [
+        ...chatMessageDtoList,
+        ...prevMessages,
+      ]);
 
-        if (feedbackDate !== lastMessageDate) {
-            setIsFeedbackDateVisible(true);
-        }
-    }, [messageList]);
+      setCursor(next_cursor);
+      setHasMore(has_next);
 
-    /* 매칭 성공후 매너/비매너 평가 버튼 클릭 시, 기존 매너/비매너 평가 내역 조회하기 */
-    const handleMannerEvaluate = () => {
-        if (chatEnterData) {
-            dispatch(setOpenMannerStatusModal());
-            onMannerValuesGet(chatEnterData.memberId);
-            onBadMannerValuesGet(chatEnterData.memberId);
-        }
-    };
+      requestAnimationFrame(() => {
+        // 새로운 메시지가 추가된 후의 스크롤 높이 차이 계산
+        const newScrollHeight = chatElement.scrollHeight;
+        const scrollDifference = newScrollHeight - previousScrollHeight;
 
-    /* 시스템 메시지를 처리하는 컴포넌트 */
-    const SystemMessage = (props: SystemMessageProps) => {
-        const { message, onClick } = props;
+        // 스크롤 위치를 기존 위치에서 중간 지점으로 이동 (새로운 메시지가 들어올 때 자연스럽게 스크롤 이동하기 위해서)
+        chatElement.scrollTop = previousScrollTop + scrollDifference;
+      });
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isLoading, hasMore, cursor, chatEnterData]);
 
-        const highlightedText = "게시한 글";
-        const parts = message.split(highlightedText);
+  /* 채팅 날짜 표시 */
+  const handleDisplayDate = (
+    messages: ChatMessageDto[],
+    index: number
+  ): boolean => {
+    if (index === 0) return true;
 
-        return (
-            <SystemMessageContainer>
-                {parts.length > 1 ? (
-                    <>
-                        {parts[0]}
-                        <UnderlinedText onClick={onClick}>{highlightedText}</UnderlinedText>
-                        {parts[1]}
-                    </>
-                ) : (
-                    message
-                )}
-            </SystemMessageContainer>
-        );
-    };
+    const currentDate = dayjs(messages[index].createdAt).format("YYYY-M-D");
+    const previousDate = dayjs(messages[index - 1].createdAt).format(
+      "YYYY-M-D"
+    );
+
+    return currentDate !== previousDate;
+  };
+
+  /* 프로필 이미지 표시 (상대방만 보여주기, 같은 시간에 온 경우 첫번째 메시지만 이미지 표시F) */
+  const handleDisplayProfileImage = (
+    messages: ChatMessageDto[],
+    index: number
+  ): boolean => {
+    if (index === 0) return true;
+
+    const currentSenderId = messages[index].senderId;
+    const previousSenderId = messages[index - 1].senderId;
+
+    const currentTime = dayjs(messages[index].createdAt).format("A hh:mm");
+    const previousTime = dayjs(messages[index - 1].createdAt).format("A hh:mm");
+
+    // 보낸 사람이 다르거나, 시간이 다르면 프로필 이미지를 표시
+    if (currentSenderId !== previousSenderId || currentTime !== previousTime) {
+      return true;
+    }
+
+    return false;
+  };
+
+  /* 메시지 시간 표시 (마지막 메시지에만 시간 표시, 상대방 메시지 중간에 오면 다시 표시) */
+  const handleDisplayTime = (
+    messages: ChatMessageDto[],
+    index: number
+  ): boolean => {
+    if (index === messages.length - 1) return true;
+
+    const currentTime = dayjs(messages[index].createdAt).format("A hh:mm");
+    const nextTime = dayjs(messages[index + 1].createdAt).format("A hh:mm");
+
+    const isSameTime = currentTime === nextTime;
+    const isSameSender =
+      messages[index].senderId === messages[index + 1].senderId;
+
+    // 시간이 같고, 보낸 사람도 같으면 마지막 메시지에만 시간 표시
+    if (isSameTime && isSameSender) {
+      return false;
+    }
+
+    return true;
+  };
+
+  /* 마지막 채팅을 보낸 후 1시간이 지난 시점에서 피드백 요청 표시 */
+  useEffect(() => {
+    const lastMessage =
+      chatEnterData?.chatMessageList.chatMessageDtoList[
+        chatEnterData.chatMessageList.chatMessageDtoList.length - 1
+      ];
+    const feedbackTimestamp = dayjs(lastMessage?.createdAt).add(1, "hour");
+    const feedbackFullDate = dayjs(feedbackTimestamp).format(
+      "YYYY-MM-DDTHH:mm:ss"
+    );
+
+    const feedbackDate = dayjs(feedbackTimestamp).format("YYYY-M-D");
+    const lastMessageDate = dayjs(lastMessage?.createdAt).format("YYYY-M-D");
+
+    setIsFeedbackDate(feedbackFullDate);
+
+    if (feedbackDate !== lastMessageDate) {
+      setIsFeedbackDateVisible(true);
+    }
+  }, [messageList]);
+
+  /* 매칭 성공후 매너/비매너 평가 버튼 클릭 시, 기존 매너/비매너 평가 내역 조회하기 */
+  const handleMannerEvaluate = () => {
+    if (chatEnterData) {
+      dispatch(setOpenMannerStatusModal());
+      onMannerValuesGet(chatEnterData.memberId);
+      onBadMannerValuesGet(chatEnterData.memberId);
+    }
+  };
+
+  /* 시스템 메시지를 처리하는 컴포넌트 */
+  const SystemMessage = (props: SystemMessageProps) => {
+    const { message, onClick } = props;
+
+    const highlightedText = "게시한 글";
+    const parts = message.split(highlightedText);
 
     return (
-        <>
-            {isReadingModal && <ReadBoard postId={isBoardId} />}
-            {isUnregisterAlert || isBlockedAlert && (
-                <ErrorBox>
-                    {isUnregisterAlert ? '탈퇴한 회원의 글입니다.' : '차단한 회원의 글입니다.'}
-                </ErrorBox>
-            )}
-            <ChatBorder>
-                <ChatMain ref={chatRef}>
-                    {messageList.map((message, index) => {
-                        const showProfileImage = handleDisplayProfileImage(messageList, index);
-                        const showTime = handleDisplayTime(messageList, index);
-
-                        return (
-                            <MsgContainer key={index}>
-                                {handleDisplayDate(messageList, index) && <Timestamp>{setChatDateFormatter(message.createdAt)}</Timestamp>}
-                                {message.systemType === 0 ? (
-                                    <SystemMessage
-                                        message={message.message}
-                                        onClick={() => handlePostOpen(message.boardId as number)}
-                                    />
-                                ) : message.systemType === 1 ? (
-                                    <>
-                                        <FeedbackDiv>
-                                            <FeedbackContainer>
-                                                <Feedback>
-                                                    <Text>매칭은 어떠셨나요?</Text>
-                                                    <Text>상대방의 매너를 평가해주세요!</Text>
-                                                    <SmileImage
-                                                        src="/assets/icons/clicked_smile.svg"
-                                                        width={22}
-                                                        height={22}
-                                                        alt="스마일 이모티콘" />
-                                                    <StyledButton onClick={handleMannerEvaluate}>
-                                                        매너평가 하기
-                                                    </StyledButton>
-                                                </Feedback>
-                                            </FeedbackContainer>
-                                        </FeedbackDiv>
-                                    </>
-                                ) : message.senderId === chatEnterData?.memberId ? (
-                                    <YourMessageContainer>
-                                        {showProfileImage && message.senderProfileImg && (
-                                            <ImageWrapper $bgColor={getProfileBgColor(message.senderProfileImg)}>
-                                                <ProfileImage
-                                                    src={`/assets/images/profile/profile${message.senderProfileImg}.svg`}
-                                                    width={38}
-                                                    height={38}
-                                                    alt="프로필 이미지"
-                                                />
-                                            </ImageWrapper>
-                                        )}
-                                        <YourDiv $hasProfileImage={showProfileImage}>
-                                            <YourMessage>{message.message}</YourMessage>
-                                            {showTime ? <YourDate>{setChatTimeFormatter(message.createdAt)}</YourDate> : null}
-                                        </YourDiv>
-                                    </YourMessageContainer>
-                                ) : (
-                                    <MyMessageContainer>
-                                        <MyDiv>
-                                            {showTime ? <MyDate>{setChatTimeFormatter(message.createdAt)}</MyDate> : null}
-                                            <MyMessage>{message.message}</MyMessage>
-                                        </MyDiv>
-                                    </MyMessageContainer>
-                                )}
-                            </MsgContainer>
-                        )
-                    })}
-                    {isLoading && (
-                        <LoadingContainer>
-                            <LoadingSpinner />
-                        </LoadingContainer>
-                    )}
-                    {isFeedbackModalOpen &&
-                        <ConfirmModal
-                            type="manner"
-                            width="315px"
-                            primaryButtonText="확인"
-                            onPrimaryClick={() => dispatch(setCloseMannerStatusModal())} />
-                    }
-                </ChatMain>
-            </ChatBorder >
-        </>
+      <SystemMessageContainer>
+        {parts.length > 1 ? (
+          <>
+            {parts[0]}
+            <UnderlinedText onClick={onClick}>{highlightedText}</UnderlinedText>
+            {parts[1]}
+          </>
+        ) : (
+          message
+        )}
+      </SystemMessageContainer>
     );
+  };
+
+  return (
+    <>
+      {isReadingModal && <ReadBoard postId={isBoardId} />}
+      {isUnregisterAlert ||
+        (isBlockedAlert && (
+          <ErrorBox>
+            {isUnregisterAlert
+              ? "탈퇴한 회원의 글입니다."
+              : "차단한 회원의 글입니다."}
+          </ErrorBox>
+        ))}
+      <ChatBorder>
+        <ChatMain ref={chatRef}>
+          {messageList.map((message, index) => {
+            const showProfileImage = handleDisplayProfileImage(
+              messageList,
+              index
+            );
+            const showTime = handleDisplayTime(messageList, index);
+
+            return (
+              <MsgContainer key={index}>
+                {handleDisplayDate(messageList, index) && (
+                  <Timestamp>
+                    {setChatDateFormatter(message.createdAt)}
+                  </Timestamp>
+                )}
+                {message.systemType === 0 ? (
+                  <SystemMessage
+                    message={message.message}
+                    onClick={() => handlePostOpen(message.boardId as number)}
+                  />
+                ) : message.systemType === 1 ? (
+                  <>
+                    <FeedbackDiv>
+                      <FeedbackContainer>
+                        <Feedback>
+                          <Text>매칭은 어떠셨나요?</Text>
+                          <Text>상대방의 매너를 평가해주세요!</Text>
+                          <SmileImage
+                            src="/assets/icons/clicked_smile.svg"
+                            width={22}
+                            height={22}
+                            alt="스마일 이모티콘"
+                          />
+                          <StyledButton onClick={handleMannerEvaluate}>
+                            매너평가 하기
+                          </StyledButton>
+                        </Feedback>
+                      </FeedbackContainer>
+                    </FeedbackDiv>
+                  </>
+                ) : message.senderId === chatEnterData?.memberId ? (
+                  <YourMessageContainer>
+                    {showProfileImage && message.senderProfileImg && (
+                      <ImageWrapper
+                        $bgColor={getProfileBgColor(message.senderProfileImg)}
+                      >
+                        <ProfileImage
+                          src={`/assets/images/profile/profile${message.senderProfileImg}.svg`}
+                          width={38}
+                          height={38}
+                          alt="프로필 이미지"
+                        />
+                      </ImageWrapper>
+                    )}
+                    <YourDiv $hasProfileImage={showProfileImage}>
+                      <YourMessage>{message.message}</YourMessage>
+                      {showTime ? (
+                        <YourDate>
+                          {setChatTimeFormatter(message.createdAt)}
+                        </YourDate>
+                      ) : null}
+                    </YourDiv>
+                  </YourMessageContainer>
+                ) : (
+                  <MyMessageContainer>
+                    <MyDiv>
+                      {showTime ? (
+                        <MyDate>
+                          {setChatTimeFormatter(message.createdAt)}
+                        </MyDate>
+                      ) : null}
+                      <MyMessage>{message.message}</MyMessage>
+                    </MyDiv>
+                  </MyMessageContainer>
+                )}
+              </MsgContainer>
+            );
+          })}
+          {isLoading && (
+            <LoadingContainer>
+              <LoadingSpinner />
+            </LoadingContainer>
+          )}
+          {isFeedbackModalOpen && (
+            <ConfirmModal
+              type="manner"
+              width="315px"
+              primaryButtonText="확인"
+              onPrimaryClick={() => dispatch(setCloseMannerStatusModal())}
+            />
+          )}
+        </ChatMain>
+      </ChatBorder>
+    </>
+  );
 };
 
 export default MessageList;
 
 const ChatBorder = styled.div`
-    padding: 0 12px;
+  padding: 0 12px;
 `;
 
 const ChatMain = styled.main`
-    border-top: 1px solid #C1B7FF;
-    padding: 10px 8px;
-    height: 471px;
-    overflow-y: auto;
-    -ms-overflow-style: none;
-    ::-webkit-scrollbar {
-        display: none;
-    }
-    scrollbar-width: none;
+  border-top: 1px solid #c1b7ff;
+  padding: 10px 8px;
+  height: 471px;
+  overflow-y: auto;
+  -ms-overflow-style: none;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  scrollbar-width: none;
 `;
 
 const spin = keyframes`
@@ -435,14 +495,14 @@ const LoadingContainer = styled.div`
 const MsgContainer = styled.div``;
 
 const Timestamp = styled.p`
-    max-width: 79px;
-    margin: 0 auto 10px;
-    text-align: center;
-    background: #000000A3;
-    border-radius: 14px;
-    padding: 4px 10px;
-    ${(props) => props.theme.fonts.regular8};
-    color: ${theme.colors.white}; 
+  max-width: 79px;
+  margin: 0 auto 10px;
+  text-align: center;
+  background: #000000a3;
+  border-radius: 14px;
+  padding: 4px 10px;
+  ${(props) => props.theme.fonts.regular8};
+  color: ${theme.colors.white};
 `;
 
 const YourMessageContainer = styled.div`
@@ -453,43 +513,42 @@ const YourMessageContainer = styled.div`
 `;
 
 const ImageWrapper = styled.div<{ $bgColor: string }>`
-    position: relative;
-    width: 47px;
-    height: 47px;
-    background: ${(props) => props.$bgColor};
-    border-radius: 50%;
+  position: relative;
+  width: 47px;
+  height: 47px;
+  background: ${(props) => props.$bgColor};
+  border-radius: 50%;
 `;
 
 const ProfileImage = styled(Image)`
-    position: absolute;
-    top:50%;
-    left:50%;
-    transform: translate(-50%, -50%);
-    cursor: pointer;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
 `;
 
 const YourDiv = styled.div<{ $hasProfileImage: boolean }>`
   display: flex;
   align-items: end;
-  margin-left: ${(props) =>
-        props.$hasProfileImage ? "11px" : "58.43px"};
+  margin-left: ${(props) => (props.$hasProfileImage ? "11px" : "58.43px")};
 `;
 
 const YourMessage = styled.div`
   ${(props) => props.theme.fonts.regular14};
-  color: ${theme.colors.gray600}; 
-  background: ${theme.colors.white}; 
+  color: ${theme.colors.gray600};
+  background: ${theme.colors.white};
   border-radius: 13px;
   padding: 5px 13px;
   max-width: 229px;
-  word-break:keep-all;
+  word-break: keep-all;
   overflow-wrap: break-word;
 `;
 
 const YourDate = styled.p`
-  margin-left:9px;
+  margin-left: 9px;
   ${(props) => props.theme.fonts.regular8};
-  color: ${theme.colors.gray700}; 
+  color: ${theme.colors.gray700};
 `;
 
 const MyMessageContainer = styled.div`
@@ -506,30 +565,30 @@ const MyDiv = styled.div`
 
 const MyMessage = styled.div`
   ${(props) => props.theme.fonts.regular14};
-  color: ${theme.colors.gray600}; 
-  background: ${theme.colors.purple300}; 
+  color: ${theme.colors.gray600};
+  background: ${theme.colors.purple300};
   border-radius: 13px;
   padding: 5px 13px;
   max-width: 196px;
-  word-break:keep-all;
+  word-break: keep-all;
   overflow-wrap: break-word;
 `;
 
 const MyDate = styled.p`
-  margin-right:5px;
+  margin-right: 5px;
   ${(props) => props.theme.fonts.regular8};
-  color: ${theme.colors.gray700}; 
+  color: ${theme.colors.gray700};
 `;
 
 const SystemMessageContainer = styled.div`
-    width: 100%;
-    text-align: center;
-    padding:11px 0px;
-    background: #000000A3;
-    ${(props) => props.theme.fonts.regular12};
-    color: ${theme.colors.white}; 
-    border-radius: 14px;
-    margin-bottom: 11px;
+  width: 100%;
+  text-align: center;
+  padding: 11px 0px;
+  background: #000000a3;
+  ${(props) => props.theme.fonts.regular12};
+  color: ${theme.colors.white};
+  border-radius: 14px;
+  margin-bottom: 11px;
 `;
 
 const UnderlinedText = styled.span`
@@ -548,7 +607,7 @@ const Feedback = styled.div`
   flex-direction: column;
   align-items: center;
   padding: 18px 15px 10px;
-  background: ${theme.colors.white}; 
+  background: ${theme.colors.white};
   border-radius: 13px;
 `;
 
@@ -558,26 +617,26 @@ const SmileImage = styled(Image)`
 
 const Text = styled.p`
   ${(props) => props.theme.fonts.regular14};
-  color: ${theme.colors.gray600}; 
+  color: ${theme.colors.gray600};
   &:first-child {
     margin-bottom: 5px;
-    }
+  }
 `;
 
 const StyledButton = styled.button`
   width: 100%;
   border-radius: 53px;
-  margin-top:12px;
+  margin-top: 12px;
   ${(props) => props.theme.fonts.semiBold12};
-  background: ${theme.colors.purple100}; 
-  color: ${theme.colors.white}; 
+  background: ${theme.colors.purple100};
+  color: ${theme.colors.white};
   padding: 10px 0;
 `;
 
 const ErrorBox = styled.div`
   position: absolute;
-  top:50%;
-  left:50%;
+  top: 50%;
+  left: 50%;
   transform: translate(-50%, -50%);
   padding: 10px 28px;
   ${(props) => props.theme.fonts.regular14};
@@ -586,4 +645,4 @@ const ErrorBox = styled.div`
   box-shadow: 0px 0px 25.3px 0px rgba(0, 0, 0, 0.15);
   border-radius: 10px;
   white-space: nowrap;
-`
+`;

--- a/src/components/common/HeaderTitle.tsx
+++ b/src/components/common/HeaderTitle.tsx
@@ -11,6 +11,7 @@ interface HeaderTitleProps {
   sub?: string;
   size?: fontSize;
   blocked?: boolean;
+  isDoubleBack?: boolean;
 }
 
 const HeaderTitle: React.FC<HeaderTitleProps> = ({
@@ -18,13 +19,22 @@ const HeaderTitle: React.FC<HeaderTitleProps> = ({
   sub,
   size = "bold",
   blocked = false,
+  isDoubleBack = false,
 }) => {
   const router = useRouter();
+
+  const handleBackClick = () => {
+    if (isDoubleBack) {
+      window.history.go(-2);
+    } else {
+      router.back();
+    }
+  };
 
   return (
     <Header>
       <StyledImage
-        onClick={() => router.back()}
+        onClick={handleBackClick}
         src="/assets/icons/left_arrow.svg"
         width={20}
         height={39}

--- a/src/components/match/SquareProfile.tsx
+++ b/src/components/match/SquareProfile.tsx
@@ -220,6 +220,18 @@ const Bubble = styled.div`
   bottom: 140px;
   left: 65%;
 
+  animation: fadeInOut 2s infinite;
+
+  @keyframes fadeInOut {
+    0%,
+    100% {
+      opacity: 0;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+
   &:before {
     border-top: 3px solid transparent;
     border-left: 6px solid transparent;
@@ -236,13 +248,13 @@ const Bubble = styled.div`
 
   &:after {
     border-top: 0 solid transparent;
-    border-left: 5.5px solid transparent;
+    border-left: 6px solid transparent;
     border-right: 4.5px solid transparent;
     border-bottom: 9px solid #e3deff;
     content: "";
     position: absolute;
-    bottom: 1px;
-    left: -3px;
+    bottom: 2px;
+    left: -2px;
     transform: rotate(-10deg);
     z-index: 100;
   }

--- a/src/redux/slices/matchingSlice.ts
+++ b/src/redux/slices/matchingSlice.ts
@@ -1,0 +1,22 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface MatchingState {
+  isComplete: boolean;
+}
+
+const initialState: MatchingState = {
+  isComplete: false,
+};
+
+const matchingSlice = createSlice({
+  name: 'matching',
+  initialState,
+  reducers: {
+    setComplete(state, action: PayloadAction<boolean>) {
+      state.isComplete = action.payload;
+    },
+  },
+});
+
+export const { setComplete } = matchingSlice.actions;
+export default matchingSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -8,6 +8,7 @@ import passwordReducer from "./slices/passwordSlice";
 import matchInfoReducer from "./slices/matchInfo";
 import chatReducer from "./slices/chatSlice";
 import notiReducer from "./slices/notiSlice";
+import matchingReducer from "./slices/matchingSlice";
 
 export const store = () => {
   return configureStore({
@@ -21,6 +22,7 @@ export const store = () => {
       matchInfo: matchInfoReducer,
       chat: chatReducer,
       noti: notiReducer,
+      matching: matchingReducer,
     },
   })
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -68,3 +68,18 @@ export const clearTokens = () => {
     sessionStorage.removeItem('name');
     sessionStorage.removeItem('profileImg');
 };
+
+/* 매칭 완료 여부 */
+export const setIsCompleted = (isCompleted: string) => {
+    if (typeof window !== 'undefined') {
+        sessionStorage.setItem("isCompleted", isCompleted);
+    }
+    return null;
+};
+
+export const getIsCompleted = () => {
+    if (typeof window !== 'undefined') {
+        return sessionStorage.getItem('isCompleted');
+    }
+    return null;
+};


### PR DESCRIPTION
## 연관 이슈

#91

<br/>

## 📁 작업 내용
실시간 매칭 오류 수정
- 매칭 성공 플로우
- sender 입장에서 상대 프로필 안 뜨는 문제 수정
- matching-retry 요청 오류 사항 수정
- matching-found-success를 receiver가 두 번씩 보내는 문제 해결

<br/>


## 📁 기타 사항

삽질을 많이 했는데.. 지금 우선적으로 또 해결해보고 있는 거는 matching-fail 이벤트에 대한 처리를 못하고 있는 문제랑, 페이지 이동 시에 매칭 나가기 이벤트를 보내는 부분입니다! 페이지 이동할 때 무조건 매칭 나가기를 시키는 게 아니라, 매칭 성공/실패 결과가 나온 후에는 페이지 이동해도 매칭 나가기가 안 보내지게 해야해서 이걸 세션 스토리지로 관리했어요! 페이지 이동 관련은 루트 layout.tsx에서 진행했습니다. 근데 잘 안 되는 것 같네요.. 그리고 매칭 중 페이지는 매칭 완료에서 뒤로가기 해도 화면이 안 나오게 해야할 것 같은데 이것도 뭔가 아예 차단되지는 않고 있어서 방법이 있는지 알아봐야야 할 것 같아요ㅠㅠ

<br/>
