### PR TITLE
[Fix] 채팅 온오프 친구, 채팅 메시지 오류 수정

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -386,7 +386,7 @@ const MessageList = (props: MessageListProps) => {
                       {showTime ? <YourDate>{setChatTimeFormatter(message.createdAt)}</YourDate> : null}
                     </YourDiv>
                   </YourMessageContainer>
-                ) : (
+                ) : message.senderId !== chatEnterData?.memberId && message.senderId !== 0 && (
                   <MyMessageContainer>
                     <MyDiv>
                       {showTime ? <MyDate>{setChatTimeFormatter(message.createdAt)}</MyDate> : null}

--- a/src/hooks/useChatFriend.ts
+++ b/src/hooks/useChatFriend.ts
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { socket } from '@/socket';
+import { connectSocket, socket } from '@/socket';
 import { setFriendOffline, setFriendOnline, setMemberId } from '@/redux/slices/chatSlice';
 
 const useChatFriend = () => {
     const dispatch = useDispatch();
 
     useEffect(() => {
+        // 소켓 연결되어 있지 않으면 소켓 연결
+        connectSocket();
+
         const handleMemberInfo = (res: any) => {
             const memberId = res.data.memberId;
             dispatch(setMemberId(memberId));

--- a/src/hooks/useChatList.ts
+++ b/src/hooks/useChatList.ts
@@ -1,10 +1,14 @@
 import { useEffect } from 'react';
-import { socket } from '@/socket';
+import { connectSocket, socket } from '@/socket';
 import { getChatrooms } from '@/api/chat';
 import { ChatroomList } from '@/interface/chat';
 
 const useChatList = (setChatrooms: (chatrooms: ChatroomList[]) => void) => {
+
     useEffect(() => {
+        // 소켓 연결되어 있지 않으면 소켓 연결
+        connectSocket();
+
         const handleJoinedNewChatroom = async () => {
             try {
                 const data = await getChatrooms();

--- a/src/hooks/useChatMessage.ts
+++ b/src/hooks/useChatMessage.ts
@@ -44,9 +44,9 @@ const useChatMessage = () => {
         };
 
         const handleMyMessage = (res: any) => {
-            if(res.data.
+            if (res.data.
                 chatroomUuid
-            ===currentChatUuid){
+                === currentChatUuid) {
                 const newMessage = res.data;
                 // 새로운 메시지 저장 (내가 쓴 메시지)
                 setNewMessage(newMessage);

--- a/src/hooks/useChatMessage.ts
+++ b/src/hooks/useChatMessage.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@/redux/store';
-import { socket } from '@/socket';
+import { connectSocket, socket } from '@/socket';
 import { setUnreadUuid } from '@/redux/slices/chatSlice';
 import { markChatAsRead } from '@/api/chat';
 import { SystemMessage, ChatMessageDto } from '@/interface/chat';
@@ -16,6 +16,9 @@ const useChatMessage = () => {
     const unreadChatUuids = useSelector((state: RootState) => state.chat.unreadUuids);
 
     useEffect(() => {
+        // 소켓 연결되어 있지 않으면 소켓 연결
+        connectSocket();
+
         const handleChatMessage = (res: any) => {
             const chatroomUuid = res.data.chatroomUuid;
             const newChatTimestamp = res.data.timestamp;


### PR DESCRIPTION
## 연관 이슈

close #130

<br/>

## 📁 작업 내용

 - 채팅 온오프 친구 오류 수정
 - 채팅 메시지 오류 수정

<br/>

## 📁 기타 사항
- 친구 온오프라인이 제대로 작동하지 않는게 왠지 소켓 연결이 제대로 안되있는 경우 같아서 새로운 이벤트 올때마다 소켓 연결 여부 확인하고, 소켓 연결되도록 했습니다.! 이번에는 제발 제대로 작동했으면 좋겠네요..
- 다른 사람 채팅이 나한테 보이는 오류도 조건을 하나 더 추가했어요!


<br/>
