### PR TITLE
[Feat] 상위 0%일 경우 1%로 표기

### DIFF
--- a/src/components/common/MannerLevelBar.tsx
+++ b/src/components/common/MannerLevelBar.tsx
@@ -31,11 +31,15 @@ const MannerLevelBar = (props: MannerLevelBarProps) => {
           <LevelBox key={level} $isColor={recentLevel === level}>
             {recentLevel === level && (
               <Recent>
-                {mannerRank && (
-                  <Percentage>{`상위 ${
-                    Math.floor(mannerRank) === 0 ? 1 : Math.floor(mannerRank)
-                  }% 의 매너레벨`}</Percentage>
-                )}
+                <Percentage>
+                  {`상위 ${
+                    mannerRank !== null &&
+                    mannerRank !== undefined &&
+                    mannerRank > 0
+                      ? Math.floor(mannerRank)
+                      : 1
+                  }% 의 매너레벨`}
+                </Percentage>
                 <DownIconWrapper level={level - 1}>
                   <ChevronDownIcon />
                 </DownIconWrapper>

--- a/src/components/common/MannerLevelBar.tsx
+++ b/src/components/common/MannerLevelBar.tsx
@@ -33,7 +33,7 @@ const MannerLevelBar = (props: MannerLevelBarProps) => {
               <Recent>
                 {mannerRank && (
                   <Percentage>{`상위 ${
-                    Math.floor(mannerRank) || 0
+                    Math.floor(mannerRank) === 0 ? 1 : Math.floor(mannerRank)
                   }% 의 매너레벨`}</Percentage>
                 )}
                 <DownIconWrapper level={level - 1}>


### PR DESCRIPTION
## 연관 이슈

close #147

<br/>

## 📁 작업 내용
상위 0%일 경우 1%로 표기

<br/>

## 🖥 구현 결과 (선택)
![image](https://github.com/user-attachments/assets/052370c2-e20a-4e7d-86ff-8404388af11a)
<br/>
