### PR TITLE
[Fix] form 데이터 대신 URLSearchParams로 수정

### DIFF
--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -11,7 +11,7 @@ export const postLogin = async ({
     password,
   }: loginProps) => {
     try {
-      const formData = new FormData();
+      const formData = new URLSearchParams();
       formData.append('email', email);
       formData.append('password', password);
 


### PR DESCRIPTION
## 연관 이슈

close #155

<br/>

## 📁 작업 내용
form 데이터 대신 URLSearchParams로 수정
<br/>
