### PR TITLE
[Fix] 토큰 만료 관련 이벤트 수신 시 리프레시 토큰 재발급

### DIFF
--- a/src/hooks/useJwtError.ts
+++ b/src/hooks/useJwtError.ts
@@ -1,8 +1,6 @@
 import { useEffect } from 'react';
 import { connectSocket, socket } from '@/socket';
-import { getAccessToken } from '@/utils/storage';
-import { isTokenExpired } from '@/utils/auth';
-import { AuthAxios, reissueToken } from '@/api/auth';
+import { reissueToken } from '@/api/auth';
 
 const useJwtError = () => {
 
@@ -12,42 +10,12 @@ const useJwtError = () => {
             connectSocket();
         }
 
-        AuthAxios.interceptors.response.use(
-            (response) => response,
-            async (error) => {
-                const { response: { status } } = error;
-
-                if (status === 401) {
-                    try {
-                        const response = await reissueToken();
-                        const newToken = response.result.refreshToken;
-
-                        // 재발급된 토큰을 로컬 저장소에 저장
-                        if (localStorage.getItem('accessToken')) {
-                            localStorage.setItem('accessToken', newToken);
-                        } else {
-                            sessionStorage.setItem('accessToken', newToken);
-                        }
-
-                        // 요청을 새로운 토큰으로 다시 전송
-                        error.config.headers['Authorization'] = `Bearer ${newToken}`;
-                        return AuthAxios(error.config);
-                    } catch (tokenReissueError) {
-                        console.error("토큰 재발급 실패:", tokenReissueError);
-                        // 재발급 실패 시 추가 처리 (로그아웃 등)
-                        throw tokenReissueError;
-                    }
-                }
-
-                return Promise.reject(error);
-            }
-        );
-
         const handleJwtExpiredError = async (res: any) => {
             const { eventName, eventData } = res.data;
 
             try {
-                const newToken = getAccessToken();
+                const response = await reissueToken();
+                const newToken = response.result.refreshToken;
                 socket?.emit(eventName, { ...eventData, token: newToken });
             } catch (error) {
                 console.error("소켓 이벤트 전송 실패:", error);
@@ -56,7 +24,8 @@ const useJwtError = () => {
 
         const handleConnectionJwtError = async () => {
             try {
-                const newToken = getAccessToken();
+                const response = await reissueToken();
+                const newToken = response.result.refreshToken;
                 socket?.emit("connection-update-token", { token: newToken });
             } catch (error) {
                 console.error("연결 업데이트 실패:", error);

--- a/src/hooks/useJwtError.ts
+++ b/src/hooks/useJwtError.ts
@@ -14,22 +14,58 @@ const useJwtError = () => {
             const { eventName, eventData } = res.data;
 
             try {
-                const response = await reissueToken();
-                const newToken = response.result.refreshToken;
-                socket?.emit(eventName, { ...eventData, token: newToken });
+              const response = await reissueToken();
+              const newToken = response.result.accessToken;
+                
+              // 로컬 또는 세션에 재발급된 토큰 저장
+              if (localStorage.getItem("accessToken")) {
+                localStorage.setItem("accessToken", response.result.accessToken);
+                localStorage.setItem(
+                  "refreshToken",
+                  response.result.refreshToken
+                );
+              } else {
+                sessionStorage.setItem(
+                  "accessToken",
+                  response.result.accessToken
+                );
+                sessionStorage.setItem(
+                  "refreshToken",
+                  response.result.refreshToken
+                );
+              }
+              socket?.emit(eventName, { ...eventData, token: newToken });
             } catch (error) {
                 console.error("소켓 이벤트 전송 실패:", error);
             }
         };
 
         const handleConnectionJwtError = async () => {
-            try {
-                const response = await reissueToken();
-                const newToken = response.result.refreshToken;
-                socket?.emit("connection-update-token", { token: newToken });
-            } catch (error) {
-                console.error("연결 업데이트 실패:", error);
+          try {
+            const response = await reissueToken();
+            const newToken = response.result.accessToken;
+
+            // 로컬 또는 세션에 재발급된 토큰 저장
+            if (localStorage.getItem("accessToken")) {
+              localStorage.setItem("accessToken", response.result.accessToken);
+              localStorage.setItem(
+                "refreshToken",
+                response.result.refreshToken
+              );
+            } else {
+              sessionStorage.setItem(
+                "accessToken",
+                response.result.accessToken
+              );
+              sessionStorage.setItem(
+                "refreshToken",
+                response.result.refreshToken
+              );
             }
+            socket?.emit("connection-update-token", { token: newToken });
+          } catch (error) {
+            console.error("연결 업데이트 실패:", error);
+          }
         };
 
         socket?.on("connection-jwt-error", handleConnectionJwtError);


### PR DESCRIPTION
## 연관 이슈

close #158

<br/>

## 📁 작업 내용

토큰 만료 관련 이벤트 수신 시 리프레시 토큰 재발급

- [기존 코드] 새로 고침 후 8080 서버 API 요청에 대한 401 응답 코드 발생 시 토큰 재발급하기 → `connection-jwt-error` 및 `jwt-expired-error` 이벤트를 수신 후 새로운 토큰 발급해서 보내는 것이 아닌, 로컬스토리지에 있는 이미 만료된 토큰을 보내고 있음. 따라서 8080 서버 요청과 3000 서버 요청이 동시에 될 때 발생하는 토큰 만료에 대해서는 이벤트 핸들링이 잘 이루어지고 있으나, 채팅과 같이 3000 서버로만 요청이 될 떄에 발생하는 토큰 만료는 만료된 토큰이 계속해서 emit 되고 있어 무한 에러 이벤트가 발생하는 오류가 생겼다.

- [수정 코드] `connection-jwt-error` 및 `jwt-expired-error` 이벤트에 대해서는 8080 서버 토큰 만료 처리와 무관하게 항상 토큰 재발급 API를 통해 재발급 받은 토큰을 보낸다.

<br/>


## 📁 기타 사항

`jwt-expired-error`는 어떤 이벤트를 요청하였는데, 함께 담겨져 온 토큰이 만료 상태일 때 발생되는 이벤트이다. 이때에는 해당 이벤트에 담겨져서 오는 기존에 발송한 eventData 명을 새로운 토큰을 담아 다시 emit 하도록 한다.

<br/>
