### PR TITLE
[Fix] useSearchParams 클라이언트 실행을 위한 Suspense 설정

### DIFF
--- a/src/app/policy/layout.tsx
+++ b/src/app/policy/layout.tsx
@@ -4,8 +4,10 @@ import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import CategoryToggle from "@/components/common/CategoryToggle";
 import styled from "styled-components";
 import { theme } from "@/styles/theme";
+import { Suspense } from "react";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
 
-const PolicyLayout = ({ children }: { children: React.ReactNode }) => {
+const PolicyLayout = ({ children }: { children?: React.ReactNode }) => {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -34,7 +36,13 @@ const PolicyLayout = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
-export default PolicyLayout;
+export default function PolicyLayoutPaging() {
+  return (
+    <Suspense fallback={<LoadingSpinner />}>
+      <PolicyLayout />
+    </Suspense>
+  );
+}
 
 const Wrapper = styled.div`
   max-width: 1440px;


### PR DESCRIPTION
## 연관 이슈

close #164

<br/>

## 📁 작업 내용
useSearchParams 클라이언트 실행을 위한 Suspense 설정

<br/>

## 📁 기타 사항

`useSearchParams` 사용할 때는 `Suspense`로 항상 감싸줘야 하는데, Layout에서는 안해도 된다고 생각을 했네요😂 수정해서 다시 올립니다. 배포 성공 확인 후에 제가 merge 하겠습니다!

<br/>
