### PR TITLE
[Feat] 마이크 타입 boolean에서 string(enum)으로 변경

### DIFF
--- a/src/api/manner.ts
+++ b/src/api/manner.ts
@@ -52,7 +52,7 @@ export const getMemberMannerLevel = async (
   }
 };
 
-/* 매너 키워드 정보 조회 */
+/* 매너 키워드 개수 조회 */
 export const getMemberMannerKeyword = async (
   memberId: number
 ): Promise<MemberMannerKeywordsResponse> => {

--- a/src/api/user/profile/put.ts
+++ b/src/api/user/profile/put.ts
@@ -1,5 +1,6 @@
 import { PutPositionRequest, PutProfileResponse } from "@/types/api/user/profile/put";
 import { AuthAxios } from "../../auth";
+import { Mike } from "@/types/user/mike";
 
 export const putProfileImage = async (
   profileImage: number
@@ -42,10 +43,10 @@ export const putPosition = async ({
   }
 };
 
-export const putMike = async (isMike: boolean): Promise<PutProfileResponse> => {
+export const putMike = async (mike: Mike): Promise<PutProfileResponse> => {
   const endpoint = "/api/v2/profile/mike";
   try {
-    const response = await AuthAxios.put(endpoint, { isMike });
+    const response = await AuthAxios.put(endpoint, { mike });
     return response.data;
   } catch (error) {
     console.error("마이크 수정 실패:", error);

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -27,6 +27,7 @@ import { mikeBooleanToId, tierStringToId } from "@/utils/custom";
 import { resetBoardFilters } from "@/redux/slices/boardSlice";
 import { rotate } from "@/styles/animation";
 import { Position } from "@/types/position/position";
+import { Mike } from "@/types/user/mike";
 
 const ITEMS_PER_PAGE = 20;
 const BUTTONS_PER_PAGE = 5;
@@ -44,7 +45,7 @@ const BoardPage = () => {
     string | number | null
   >(null);
   const [selectedTier, setSelectedTier] = useState<string | null>(null);
-  const [selectedMic, setSelectedMic] = useState<boolean | string | null>(null);
+  const [selectedMic, setSelectedMic] = useState<Mike | null>(null);
   const [showAlert, setShowAlert] = useState(false);
   const [refresh, setRefresh] = useState(false);
 
@@ -173,10 +174,10 @@ const BoardPage = () => {
     dispatch(resetBoardFilters());
     switch (id) {
       case 1:
-        setSelectedMic(true);
+        setSelectedMic("AVAILABLE");
         break;
       case 2:
-        setSelectedMic(false);
+        setSelectedMic("UNAVAILABLE");
         break;
       default:
         setSelectedMic(null);

--- a/src/app/guide/page.tsx
+++ b/src/app/guide/page.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import RadioCard from "@/components/common/RadioCard";
 import ConfirmModal from "@/components/common/ConfirmModal";
 import Toggle from "@/components/common/Toggle";
+import { Mike } from "@/types/user/mike";
 
 const Guide = () => {
   /* Input State */
@@ -28,7 +29,7 @@ const Guide = () => {
   const [isPosition, setIsPosition] = useState("");
 
   /* Toggle */
-  const [isOn, setisOn] = useState(false);
+  const [isOn, setisOn] = useState<Mike>("UNAVAILABLE");
 
   const handleOptionChange = (value: string) => {
     setIsSelected(value);
@@ -59,7 +60,7 @@ const Guide = () => {
 
   /* Toggle */
   const toggleHandler = () => {
-    setisOn(!isOn);
+    setisOn(isOn === "AVAILABLE" ? "UNAVAILABLE" : "AVAILABLE");
   };
   const handlePosition = (value: string) => {
     setIsPosition(value);

--- a/src/app/match/profile/page.tsx
+++ b/src/app/match/profile/page.tsx
@@ -96,7 +96,7 @@ const ProfilePage = () => {
     const matchingData = {
       matchingType,
       gameMode,
-      mike: matchInfo.mike ?? false,
+      mike: matchInfo.mike ?? "UNAVAILABLE",
       mainP: (matchInfo.mainP ?? 0).toString(),
       subP: (matchInfo.subP ?? 0).toString(),
       wantP: (matchInfo.wantP ?? 0).toString(),

--- a/src/app/matching/complete/page.tsx
+++ b/src/app/matching/complete/page.tsx
@@ -18,6 +18,7 @@ import { setComplete } from "@/redux/slices/matchingSlice";
 import { setIsCompleted } from "@/utils/storage";
 import { getMyProfile } from "@/api/user/profile/get";
 import { Position } from "@/types/position/position";
+import { Mike } from "@/types/user/mike";
 
 interface User {
   memberId: number;
@@ -31,7 +32,7 @@ interface User {
   mainPosition: Position;
   subPosition: Position;
   wantPosition: Position;
-  mike: boolean;
+  mike: Mike;
   gameStyleList: string[];
 }
 
@@ -59,7 +60,7 @@ const Complete = () => {
     mainPosition: "ANY",
     subPosition: "ANY",
     wantPosition: "ANY",
-    mike: false,
+    mike: "UNAVAILABLE",
     gameStyleList: [],
   });
 
@@ -75,7 +76,7 @@ const Complete = () => {
     mainPosition: "ANY",
     subPosition: "ANY",
     wantPosition: "ANY",
-    mike: false,
+    mike: "UNAVAILABLE",
     gameStyleList: [],
   });
 

--- a/src/app/matching/progress/page.tsx
+++ b/src/app/matching/progress/page.tsx
@@ -18,6 +18,7 @@ import { useDispatch } from "react-redux";
 import { setBoardFilters } from "@/redux/slices/boardSlice";
 import { setIsCompleted } from "@/utils/storage";
 import { Position } from "@/types/position/position";
+import { Mike } from "@/types/user/mike";
 
 interface User {
   memberId: number;
@@ -31,7 +32,7 @@ interface User {
   mainPosition: Position;
   subPosition: Position;
   wantPosition: Position;
-  mike: boolean;
+  mike: Mike;
   gameStyleList: string[];
 }
 
@@ -63,7 +64,7 @@ const Progress = () => {
     mainPosition: (searchParams.get("mainPosition") as Position) || "ANY",
     subPosition: (searchParams.get("subPosition") as Position) || "ANY",
     wantPosition: (searchParams.get("wantPosition") as Position) || "ANY",
-    mike: searchParams.get("mike") === "true",
+    mike: (searchParams.get("mike") as Mike) || "AVAILABLE",
     gameStyleList: (searchParams.get("gameStyleList") || "").split(","),
   };
 

--- a/src/components/common/Toggle.tsx
+++ b/src/components/common/Toggle.tsx
@@ -1,10 +1,11 @@
 import { theme } from "@/styles/theme";
+import { Mike } from "@/types/user/mike";
 import styled from "styled-components";
 import { css } from "styled-components";
 
 interface ToggleProps {
-  isOn: boolean;
-  onToggle: (state: boolean) => void;
+  isOn: Mike;
+  onToggle: (state: Mike) => void;
   disabled?: boolean;
   type?: string;
   isBlind?: boolean;
@@ -14,7 +15,7 @@ const Toggle = (props: ToggleProps) => {
   const { isOn, onToggle, disabled = false, type, isBlind = false } = props;
 
   const toggleHandler = () => {
-    const newState = !isOn;
+    const newState = isOn === "AVAILABLE" ? "UNAVAILABLE" : "AVAILABLE";
     onToggle(newState);
   };
 
@@ -26,9 +27,15 @@ const Toggle = (props: ToggleProps) => {
         $type={type}
         $isBlind={isBlind}
       >
-        <div className={`toggle-circle ${isOn ? null : "toggle--unchecked"}`} />
         <div
-          className={`toggle-container ${isOn ? null : "toggle--unchecked"}`}
+          className={`toggle-circle ${
+            isOn === "AVAILABLE" ? null : "toggle--unchecked"
+          }`}
+        />
+        <div
+          className={`toggle-container ${
+            isOn === "AVAILABLE" ? null : "toggle--unchecked"
+          }`}
         />
       </ToggleContainer>
     </>

--- a/src/components/createBoard/PostBoard.tsx
+++ b/src/components/createBoard/PostBoard.tsx
@@ -26,6 +26,7 @@ import { setUserProfile } from "@/redux/slices/userSlice";
 import { theme } from "@/styles/theme";
 import { setClosePostingModal } from "@/redux/slices/modalSlice";
 import { getMyProfile } from "@/api/user/profile/get";
+import { Mike } from "@/types/user/mike";
 
 interface PostBoardProps {
   onClose: () => void;
@@ -68,7 +69,9 @@ const PostBoard = (props: PostBoardProps) => {
       want: currentPost?.wantPosition || user?.wantP || "ANY",
     }
   );
-  const [isMicOn, setIsMicOn] = useState<boolean>(currentPost?.mike || false);
+  const [isMicOn, setIsMicOn] = useState<Mike>(
+    currentPost?.mike || "UNAVAILABLE"
+  );
   const gameStyleIds =
     user?.gameStyleResponseList?.map((item) => item.gameStyleId) || [];
   const [selectedStyleIds, setSelectedStyleIds] = useState<number[]>(
@@ -169,7 +172,7 @@ const PostBoard = (props: PostBoardProps) => {
 
   /* 마이크 유무 선택 */
   const toggleMicHandler = () => {
-    setIsMicOn(!isMicOn);
+    setIsMicOn(isMicOn === "AVAILABLE" ? "UNAVAILABLE" : "AVAILABLE");
   };
 
   /* 글 수정 */

--- a/src/components/match/GameStyle.tsx
+++ b/src/components/match/GameStyle.tsx
@@ -11,6 +11,7 @@ import { useDispatch } from "react-redux";
 import { updateGameStyles } from "@/redux/slices/matchInfo";
 import { setUserMike } from "@/redux/slices/userSlice";
 import { putGameStyle, putMike } from "@/api/user/profile/put";
+import { Mike } from "@/types/user/mike";
 
 type profileType = "me" | "other" | "none" | "mini";
 
@@ -22,7 +23,7 @@ interface GameStyle {
 interface GameStyleProps {
   gameStyleResponseDTOList: GameStyle[];
   profileType: profileType;
-  mike: boolean;
+  mike: Mike;
   handleMike?: () => void;
 }
 
@@ -39,7 +40,7 @@ const GameStyle = (props: GameStyleProps) => {
   const [selectedStyles, setSelectedStyles] = useState<number[]>(
     gameStyleResponseDTOList.map((style) => style.gameStyleId)
   );
-  const [isMike, setIsMike] = useState(mike);
+  const [mikeState, setMikeState] = useState(mike);
 
   useEffect(() => {
     if (gameStyleResponseDTOList.length > 0) {
@@ -96,8 +97,9 @@ const GameStyle = (props: GameStyleProps) => {
     .filter(Boolean);
 
   const handleChangeMike = async () => {
-    const newMikeValue = !isMike;
-    setIsMike(newMikeValue);
+    const newMikeValue =
+      mikeState === "AVAILABLE" ? "UNAVAILABLE" : "AVAILABLE";
+    setMikeState(newMikeValue);
 
     try {
       await putMike(newMikeValue);

--- a/src/components/match/Profile.tsx
+++ b/src/components/match/Profile.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/api/friend/request";
 import { deleteFriend } from "@/api/friend/delete";
 import { blockMember, unblockMember } from "@/api/block/block";
+import { Mike as MikeType } from "@/types/user/mike";
 
 type profileType = "normal" | "wind" | "other" | "me";
 
@@ -82,7 +83,7 @@ const Profile: React.FC<Profile> = ({
   const [selectedBox, setSelectedBox] = useState("");
 
   /* user부터 가져오는 상태들 */
-  const [isMike, setIsMike] = useState<boolean>(user.mike);
+  const [isMike, setIsMike] = useState<MikeType>(user.mike);
   const [positionValue, setPositionValue] = useState<PositionState>({
     main: user.mainP,
     sub: user.subP,
@@ -139,7 +140,7 @@ const Profile: React.FC<Profile> = ({
   }, [isMike]);
 
   const handleMike = () => {
-    setIsMike(!isMike);
+    setIsMike(isMike === "AVAILABLE" ? "UNAVAILABLE" : "AVAILABLE");
     dispatch(updateMike(isMike));
   };
 

--- a/src/components/match/SquareProfile.tsx
+++ b/src/components/match/SquareProfile.tsx
@@ -10,6 +10,7 @@ import { setAbbrevTier, setPositionImg } from "@/utils/custom";
 import { getProfileBgColor } from "@/utils/profile";
 import { toLowerCaseString } from "@/utils/string";
 import { Position as PositionType } from "@/types/position/position";
+import { Mike } from "@/types/user/mike";
 
 interface User {
   memberId: number;
@@ -23,7 +24,7 @@ interface User {
   mainPosition: PositionType;
   subPosition: PositionType;
   wantPosition: PositionType;
-  mike: boolean;
+  mike: Mike;
   gameStyleList?: string[];
 }
 

--- a/src/components/readBoard/Mic.tsx
+++ b/src/components/readBoard/Mic.tsx
@@ -1,45 +1,47 @@
 import styled from "styled-components";
 import { theme } from "@/styles/theme";
 import Image from "next/image";
+import { Mike } from "@/types/user/mike";
 
 interface MicProps {
-    status: boolean;
+  status: Mike;
 }
 
 const Mic = (props: MicProps) => {
-    const { status } = props;
+  const { status } = props;
 
-    return (
-        <Wrapper>
-            <Image
-                src={!!status ?
-                    "/assets/icons/mic_on_no_bg.svg"
-                    :
-                    "/assets/icons/mic_off_no_bg.svg"}
-                width={27}
-                height={33}
-                alt={`mic ${!!status ? "on" : "off"}`} />
-            <MicText className={!!status ? 'on' : 'off'}>마이크 {!!status ? "ON" : "OFF"}</MicText>
-        </Wrapper>
-    )
+  return (
+    <Wrapper>
+      <Image
+        src={`/assets/icons/mic_${
+          status === "AVAILABLE" ? "on" : "off"
+        }_no_bg.svg`}
+        width={27}
+        height={33}
+        alt={`mic ${status === "AVAILABLE" ? "on" : "off"}`}
+      />
+      <MicText className={status === "AVAILABLE" ? "on" : "off"}>
+        마이크 {status === "AVAILABLE" ? "ON" : "OFF"}
+      </MicText>
+    </Wrapper>
+  );
 };
 
 export default Mic;
 
 const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
 const MicText = styled.p`
-    ${(props) => props.theme.fonts.bold10};
-    margin-top: 6px;
-    &.on {
-        color:${theme.colors.purple100};
-    }
-    &.off {
-        color:#606060;
-    }
+  ${(props) => props.theme.fonts.bold10};
+  margin-top: 6px;
+  &.on {
+    color: ${theme.colors.purple100};
+  }
+  &.off {
+    color: #606060;
+  }
 `;
-

--- a/src/components/user/BlindProfile.tsx
+++ b/src/components/user/BlindProfile.tsx
@@ -57,7 +57,7 @@ const BlindProfile = () => {
                   <Mike>
                     마이크
                     <Toggle
-                      isOn={false}
+                      isOn={"UNAVAILABLE"}
                       onToggle={() => {}}
                       disabled={true}
                       isBlind={true}

--- a/src/interface/board.ts
+++ b/src/interface/board.ts
@@ -1,5 +1,6 @@
 import { MannerKeywordDTO } from "@/types/api/board/board";
 import { Position } from "@/types/position/position";
+import { Mike } from "@/types/user/mike";
 
 export interface ChampionResponseDTOList {
   championId: number;
@@ -27,7 +28,7 @@ export interface BoardDetail {
   championResponseList?: ChampionResponseDTOList[];
   winRate: number;
   createdAt: string;
-  mike: boolean;
+  mike: Mike;
 }
 
 export interface BoardList {
@@ -49,7 +50,7 @@ export interface MemberPost {
   mannerLevel: number;
   mannerKeywords?: MannerKeywordDTO[];
   tier: string;
-  mike: boolean;
+  mike: Mike;
   championResponseList?: ChampionResponseDTOList[];
   championResponseDTOList?: ChampionResponseDTOList[];
   gameMode: number;
@@ -69,7 +70,7 @@ export interface PostReq {
   mainPosition: Position;
   subPosition: Position;
   wantPosition: Position;
-  mike: boolean;
+  mike: Mike;
   gameStyles: number[];
   contents: string;
 }

--- a/src/interface/profile.ts
+++ b/src/interface/profile.ts
@@ -1,4 +1,5 @@
 import { Position } from "@/types/position/position";
+import { Mike } from "@/types/user/mike";
 
 export type profileType = "normal" | "wind" | "other" | "me";
 
@@ -15,7 +16,7 @@ export interface GameStyle {
 export interface User {
   id?: number;
   profileImg: number;
-  mike: boolean;
+  mike: Mike;
   email?: string;
   gameName: string;
   tag: string;

--- a/src/redux/slices/boardSlice.ts
+++ b/src/redux/slices/boardSlice.ts
@@ -1,4 +1,5 @@
 import { Position } from '@/types/position/position';
+import { Mike } from '@/types/user/mike';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface BoardState {
@@ -6,7 +7,7 @@ interface BoardState {
   mode: number | null;
   tier: string | null;
   mainPosition: Position;
-  mike: boolean | null;
+  mike: Mike | null;
 }
 
 const initialState: BoardState = {

--- a/src/redux/slices/matchInfo.ts
+++ b/src/redux/slices/matchInfo.ts
@@ -1,8 +1,9 @@
 import { Position } from '@/types/position/position';
+import { Mike } from '@/types/user/mike';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export interface MatchInfoState {
-  mike: boolean | null;                        // 마이크 사용 여부
+  mike: Mike | null;                        // 마이크 사용 여부
   mainP: Position;                             // 주 포지션
   subP: Position;                              // 부 포지션
   wantP: Position;                             // 원하는 포지션
@@ -10,7 +11,7 @@ export interface MatchInfoState {
 }
 
 const initialState: MatchInfoState = {
-  mike: false,
+  mike: "UNAVAILABLE",
   mainP: "ANY",
   subP: "ANY",
   wantP: "ANY",
@@ -46,7 +47,7 @@ const matchInfoSlice = createSlice({
     },
 
      // 마이크만 업데이트
-    updateMike: (state, action: PayloadAction<boolean>) => {
+    updateMike: (state, action: PayloadAction<Mike>) => {
       state.mike = action.payload;
     },
   },

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -1,11 +1,12 @@
 import { ChampionList, GameStyleList } from '@/interface/profile';
 import { Position } from '@/types/position/position';
+import { Mike } from '@/types/user/mike';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface UserState {
   id?: number | undefined;
   profileImg: number;
-  mike: boolean;
+  mike: Mike;
   email: string;
   gameName: string;
   tag: string;
@@ -31,7 +32,7 @@ interface UserState {
 const initialState: UserState = {
   id: 0,
   profileImg: 1,
-  mike: false,
+  mike: "UNAVAILABLE",
   email: "",
   gameName: "",
   tag: "",
@@ -67,7 +68,7 @@ export const userSlice = createSlice({
     setUserProfileImg: (state, action: PayloadAction<number>) => {
       state.profileImg = action.payload;
     },
-    setUserMike: (state, action: PayloadAction<boolean>) => {
+    setUserMike: (state, action: PayloadAction<Mike>) => {
       state.mike = action.payload;
     },
     setUserProfile: (state: any, action: PayloadAction<Partial<UserState>>) => {
@@ -76,7 +77,7 @@ export const userSlice = createSlice({
     clearUserProfile(state) {
       state.id = 0;
       state.profileImg = 1;
-      state.mike = false;
+      state.mike = "UNAVAILABLE";
       state.email = '';
       state.gameName = '';
       state.tag = '';

--- a/src/types/api/board/board.d.ts
+++ b/src/types/api/board/board.d.ts
@@ -1,5 +1,6 @@
 import { Position } from "@/types/position/position";
 import { ApiResponse } from "../api";
+import { Mike } from "@/types/user/mike";
 
 // 기본 DTO 인터페이스들
 interface ChampionResponseDTO {
@@ -30,7 +31,7 @@ interface GameInfo {
   mainPosition: Position;
   subPosition: Position;
   wantPosition: Position;
-  mike: boolean;
+  mike: Mike;
   gameStyles: Array<number>;
 }
 

--- a/src/types/api/user/profile/get.d.ts
+++ b/src/types/api/user/profile/get.d.ts
@@ -1,10 +1,11 @@
 import { ChampionList, GameStyleList } from "@/interface/profile";
 import { ApiResponse } from "../api";
+import { Mike } from "@/types/user/mike";
 
 interface BaseProfileData {
   id: number;
   profileImg: number;
-  mike: boolean;
+  mike: Mike;
   gameName: string;
   tag: string;
   tier: string;

--- a/src/types/user/mike.d.ts
+++ b/src/types/user/mike.d.ts
@@ -1,0 +1,1 @@
+export type Mike = "UNAVAILABLE" | "AVAILABLE" | "ONLY_LISTEN";

--- a/src/utils/custom.tsx
+++ b/src/utils/custom.tsx
@@ -1,5 +1,6 @@
 import dayjs from "@/libs/dayjs";
 import { Position } from "@/types/position/position";
+import { Mike } from "@/types/user/mike";
 
 export function setQueueType(gameMode: number) {
   switch (gameMode) {
@@ -112,13 +113,13 @@ export const tierStringToId = (tier: string | null) => {
   }
 };
 
-export const mikeBooleanToId = (mike: boolean | null) => {
+export const mikeBooleanToId = (mike: Mike | null) => {
   switch (mike) {
     case null:
       return 0;
-    case true:
+    case "AVAILABLE":
       return 1;
-    case false:
+    case "UNAVAILABLE":
       return 2;
     default:
       return null;


### PR DESCRIPTION
## 연관 이슈
close #180

<br/>

## 📁 작업 내용

API 변경에 따라, 마이크 타입 boolean에서 string(enum)으로 변경


- [x] 유저 프로필 조회
- [x] 다른 유저 프로필 조회
- [x] 마이크 여부 선택 및 수정
- [x] 게시판 관련
<br/>

## 📁 기타 사항
- 기존 마이크 유/무 상태에서 듣기만 가능 상태가 추가되면서,
boolean 에서 `UNAVAILABLE`, `AVAILABLE`, `ONLY_LISTEN` string으로 타입이 변경되었습니다.
마이크 관련 enum은 `types/user/mike.d.ts` 파일에서 import 해서 사용하시면 됩니다:)
<br/>
