### PR TITLE
[Fix] 채팅내역 불러오기 오류 해결 및 채팅방 내에서 채팅창 이동하기

### DIFF
--- a/src/app/matching/complete/page.tsx
+++ b/src/app/matching/complete/page.tsx
@@ -13,12 +13,17 @@ import ConfirmModal from "@/components/common/ConfirmModal";
 import ChatLayout from "@/components/chat/ChatLayout";
 import { RootState } from "@/redux/store";
 import { useDispatch, useSelector } from "react-redux";
-import { openChatRoom, setChatRoomUuid } from "@/redux/slices/chatSlice";
+import {
+  openChatRoom,
+  setChatEnterType,
+  setChatRoomUuid,
+} from "@/redux/slices/chatSlice";
 import { setComplete } from "@/redux/slices/matchingSlice";
 import { setIsCompleted } from "@/utils/storage";
 import { getMyProfile } from "@/api/user/profile/get";
 import { Position } from "@/types/position/position";
 import { Mike } from "@/types/user/mike";
+import Layout from "@/components/chat/Layout";
 
 interface User {
   memberId: number;
@@ -311,6 +316,7 @@ const Complete = () => {
     const data = res.data;
     dispatch(setChatRoomUuid(data.chatroomUuid)); // 채팅방 UUID 설정
     dispatch(openChatRoom()); // 채팅방 열기
+    dispatch(setChatEnterType(1)); // 대화방에서 채팅방 입장
   };
 
   // matching-fail 수신 시 타이머 종료 및 실패 모달 표시
@@ -348,7 +354,7 @@ const Complete = () => {
 
   return (
     <Suspense>
-      {isChatRoomOpen && <ChatLayout apiType={1} />}
+      {isChatRoomOpen && <Layout />}
       <Wrapper>
         <MatchContent>
           <HeaderTitle

--- a/src/components/board/Table.tsx
+++ b/src/components/board/Table.tsx
@@ -15,11 +15,11 @@ import { setCloseModal, setOpenReadingModal } from "@/redux/slices/modalSlice";
 import { useRouter } from "next/navigation";
 import Alert from "../common/Alert";
 import ConfirmModal from "../common/ConfirmModal";
-import ChatLayout from "../chat/ChatLayout";
 import Champion from "../readBoard/Champion";
 import { BoardDetail } from "@/interface/board";
 import { getProfileBgColor } from "@/utils/profile";
 import { toLowerCaseString } from "@/utils/string";
+import Layout from "../chat/Layout";
 
 interface TableTitleProps {
   id: number;
@@ -140,7 +140,7 @@ const Table = (props: TableProps) => {
 
       {isReadingModal && !isChatRoomOpen && <ReadBoard postId={isBoardId} />}
 
-      {isChatRoomOpen && <ChatLayout apiType={2} />}
+      {isChatRoomOpen && <Layout />}
 
       {copiedAlert && <Copied>소환사명이 클립보드에 복사되었습니다.</Copied>}
       <TableWrapper>

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -56,10 +56,11 @@ interface System {
 
 interface ChatLayoutProps {
   apiType: number;
+  onDragStart: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 const ChatLayout = (props: ChatLayoutProps) => {
-  const { apiType } = props;
+  const { apiType, onDragStart } = props;
   const dispatch = useDispatch();
 
   const [isMoreBoxOpen, setIsMoreBoxOpen] = useState(false);
@@ -611,12 +612,14 @@ const ChatLayout = (props: ChatLayoutProps) => {
       <Overlay>
         {isChatRoomOpen && chatEnterData && isChatUuid !== null && (
           <Wrapper onClick={handleOutsideModalClick}>
-            <MessageHeader
-              isMoreBoxOpen={isMoreBoxOpen}
-              chatEnterData={chatEnterData}
-              onMoreBoxOpen={handleMoreBoxOpen}
-              menuItems={menuItems}
-            />
+            <HeaderWrapper onMouseDown={onDragStart}>
+              <MessageHeader
+                isMoreBoxOpen={isMoreBoxOpen}
+                chatEnterData={chatEnterData}
+                onMoreBoxOpen={handleMoreBoxOpen}
+                menuItems={menuItems}
+              />
+            </HeaderWrapper>
             <MessageList
               chatEnterData={chatEnterData}
               systemMessage={systemMessage}
@@ -834,13 +837,7 @@ const ChatLayout = (props: ChatLayoutProps) => {
 
 export default ChatLayout;
 
-const Overlay = styled.div`
-  position: fixed;
-  top: 50%;
-  right: 8%;
-  transform: translate(0, -50%);
-  z-index: 1;
-`;
+const Overlay = styled.div``;
 
 const Wrapper = styled.div`
   position: relative;
@@ -848,7 +845,12 @@ const Wrapper = styled.div`
   border-radius: 20px;
   display: flex;
   flex-direction: column;
-  width: 418px;
+  width: 100%;
+`;
+
+const HeaderWrapper = styled.div`
+  user-select: auto;
+  cursor: move;
 `;
 
 const CheckContent = styled.div`

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -89,6 +89,9 @@ const ChatLayout = (props: ChatLayoutProps) => {
   const isChatUuid = useSelector(
     (state: RootState) => state.chat.isChatRoomUuid
   );
+  const chatEnterType = useSelector(
+    (state: RootState) => state.chat.chatEnterType
+  );
   const isModalType = useSelector((state: RootState) => state.modal.modalType);
   const isUser = useSelector((state: RootState) => state.user);
 
@@ -105,7 +108,7 @@ const ChatLayout = (props: ChatLayoutProps) => {
 
     try {
       // 친구목록에서 채팅방 입장
-      if (apiType === 0 && typeof isChatUuid === "number") {
+      if (chatEnterType === 0 && typeof isChatUuid === "number") {
         const data = await enterUsingMemberId({ memberId: isChatUuid });
         setChatEnterData(data.data);
         dispatch(setCurrentChatUuid(data.data.uuid));
@@ -113,7 +116,7 @@ const ChatLayout = (props: ChatLayoutProps) => {
       }
 
       // 대화방에서 채팅방 입장
-      if (apiType === 1 && typeof isChatUuid === "string") {
+      if (chatEnterType === 1 && typeof isChatUuid === "string") {
         const data = await enterUsingUuid({ uuid: isChatUuid });
         setChatEnterData(data.data);
         dispatch(setCurrentChatUuid(data.data.uuid));
@@ -121,7 +124,7 @@ const ChatLayout = (props: ChatLayoutProps) => {
       }
 
       // 게시글에서 채팅방 입장
-      if (apiType === 2 && typeof isChatUuid === "number") {
+      if (chatEnterType === 2 && typeof isChatUuid === "number") {
         const data = await enterUsingBoardId({ boardId: isChatUuid });
         setChatEnterData(data.data);
         dispatch(setCurrentChatUuid(data.data.uuid));

--- a/src/components/chat/ChatRoomList.tsx
+++ b/src/components/chat/ChatRoomList.tsx
@@ -9,7 +9,7 @@ import { RootState } from "@/redux/store";
 import { getChatrooms } from "@/api/chat/chat";
 import ChatRoomItem from "./ChatRoomItem";
 import useChatMessage from "@/hooks/useChatMessage";
-import { setCurrentChatUuid } from "@/redux/slices/chatSlice";
+import { setChatEnterType, setCurrentChatUuid } from "@/redux/slices/chatSlice";
 import useChatList from "@/hooks/useChatList";
 import {
   acceptFriendRequest,
@@ -285,7 +285,10 @@ const ChatRoomList = (props: ChatRoomListProps) => {
           <ChatRoomItem
             key={room.uuid}
             room={room}
-            onChatRoom={(id) => onChatRoom(id)}
+            onChatRoom={(id) => {
+              onChatRoom(id);
+              dispatch(setChatEnterType(1)); // 대화방에서 채팅방 입장
+            }}
             isMoreBoxOpen={isMoreBoxOpen}
             handleMoreBoxOpen={handleMoreBoxOpen}
             moreMenuItems={moreMenuItems}

--- a/src/components/chat/FriendItem.tsx
+++ b/src/components/chat/FriendItem.tsx
@@ -4,6 +4,8 @@ import Image from "next/image";
 import DeleteFriend from "./DeleteFriend";
 import { getProfileBgColor } from "@/utils/profile";
 import { FriendList } from "@/types/friend/friendList";
+import { setChatEnterType } from "@/redux/slices/chatSlice";
+import { useDispatch } from "react-redux";
 
 interface FriendItemProps {
   friend: FriendList;
@@ -28,10 +30,15 @@ const FriendItem = (props: FriendItemProps) => {
     handleDeleteFriend,
   } = props;
 
+  const dispatch = useDispatch();
+
   return (
     <UserContent
       onContextMenu={(event) => onContextMenu(event, friend.memberId)}
-      onClick={() => onChatRoom(friend.memberId)}
+      onClick={() => {
+        onChatRoom(friend.memberId);
+        dispatch(setChatEnterType(0)); // 친구목록에서 채팅방 입장
+      }}
     >
       {deleteMenu.friendId === friend.memberId && (
         <DeleteFriend

--- a/src/components/chat/Layout.tsx
+++ b/src/components/chat/Layout.tsx
@@ -499,60 +499,66 @@ const Layout = () => {
 
   return (
     <>
-      {isChatRoomOpen && isChatUuid !== null ? (
-        <ChatLayout apiType={activeTab} />
-      ) : (
-        <Overlay $top={position.top} $left={position.left}>
-          <Wrapper onClick={handleOutsideModalClick}>
-            <Header onMouseDown={handleDragStart}>
-              <HeaderTitle>메신저</HeaderTitle>
-              <CloseButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  dispatch(closeChat());
-                  dispatch(resetPosition());
-                }}
-                onMouseDown={(e) => {
-                  e.stopPropagation();
-                }}
-              >
-                <CloseImage
-                  src="/assets/icons/close.svg"
-                  width={12}
-                  height={12}
-                  alt="닫기"
-                />
-              </CloseButton>
-            </Header>
-            <Tabs tabs={tabs} activeTab={activeTab} onTabClick={setActiveTab} />
-            {activeTab === 0 && <SearchBar onSearch={handleSearch} />}
-            <ChatMain className={activeTab === 0 ? "friend" : "chat"}>
-              <Content className={activeTab === 0 ? "friend" : "chat"}>
-                {activeTab === 0 ? (
-                  <div>
-                    <ChatFriendList
-                      onChatRoom={handleGoToChatRoom}
-                      friends={friends}
-                      favoriteFriends={favoriteFriends}
-                      onFavoriteToggle={handleFavoriteToggle}
-                      handleFetchFriendsList={handleFetchFriendsList}
-                      isSearching={isSearching}
-                    />
-                  </div>
-                ) : (
-                  <ChatRoomList
-                    onChatRoom={handleGoToChatRoom}
-                    activeTab={activeTab}
-                    isMoreBoxOpen={isMoreBoxOpen}
-                    setIsMoreBoxOpen={setIsMoreBoxOpen}
-                    handleMoreBoxOpen={handleMoreBoxOpen}
+      <Overlay $top={position.top} $left={position.left}>
+        <Wrapper onClick={handleOutsideModalClick}>
+          {isChatRoomOpen && isChatUuid !== null ? (
+            <ChatLayout apiType={activeTab} onDragStart={handleDragStart} />
+          ) : (
+            <>
+              <Header onMouseDown={handleDragStart}>
+                <HeaderTitle>메신저</HeaderTitle>
+                <CloseButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    dispatch(closeChat());
+                    dispatch(resetPosition());
+                  }}
+                  onMouseDown={(e) => {
+                    e.stopPropagation();
+                  }}
+                >
+                  <CloseImage
+                    src="/assets/icons/close.svg"
+                    width={12}
+                    height={12}
+                    alt="닫기"
                   />
-                )}
-              </Content>
-            </ChatMain>
-          </Wrapper>
-        </Overlay>
-      )}
+                </CloseButton>
+              </Header>
+              <Tabs
+                tabs={tabs}
+                activeTab={activeTab}
+                onTabClick={setActiveTab}
+              />
+              {activeTab === 0 && <SearchBar onSearch={handleSearch} />}
+              <ChatMain className={activeTab === 0 ? "friend" : "chat"}>
+                <Content className={activeTab === 0 ? "friend" : "chat"}>
+                  {activeTab === 0 ? (
+                    <div>
+                      <ChatFriendList
+                        onChatRoom={handleGoToChatRoom}
+                        friends={friends}
+                        favoriteFriends={favoriteFriends}
+                        onFavoriteToggle={handleFavoriteToggle}
+                        handleFetchFriendsList={handleFetchFriendsList}
+                        isSearching={isSearching}
+                      />
+                    </div>
+                  ) : (
+                    <ChatRoomList
+                      onChatRoom={handleGoToChatRoom}
+                      activeTab={activeTab}
+                      isMoreBoxOpen={isMoreBoxOpen}
+                      setIsMoreBoxOpen={setIsMoreBoxOpen}
+                      handleMoreBoxOpen={handleMoreBoxOpen}
+                    />
+                  )}
+                </Content>
+              </ChatMain>
+            </>
+          )}
+        </Wrapper>
+      </Overlay>
 
       {/* 채팅창 나가기 팝업 */}
       {!isChatRoomOpen && isModalType === "leave" && selectedChatroom && (

--- a/src/components/chat/MessageHeader.tsx
+++ b/src/components/chat/MessageHeader.tsx
@@ -80,7 +80,7 @@ const MessageHeader = (props: MessageHeaderProps) => {
               >
                 {chatEnterData.gameName}
               </UserName>
-              {chatEnterData?.friend &&
+              {chatEnterData?.friend && (
                 <>
                   {onlineFriends.includes(chatEnterData.memberId) ? (
                     <>
@@ -96,16 +96,17 @@ const MessageHeader = (props: MessageHeaderProps) => {
                     <OnlineStatus>오프라인</OnlineStatus>
                   )}
                 </>
-              }
+              )}
             </Div>
           </Middle>
-          <ThreeDotsImage
-            onClick={onMoreBoxOpen}
-            src="/assets/icons/three_dots_button.svg"
-            width={3}
-            height={15}
-            alt="상세보기"
-          />
+          <ThreeDotsButton onClick={onMoreBoxOpen}>
+            <ThreeDotsImage
+              src="/assets/icons/three_dots_button.svg"
+              width={3}
+              height={15}
+              alt="상세보기"
+            />
+          </ThreeDotsButton>
         </ChatHeader>
       )}
     </>
@@ -148,6 +149,7 @@ const ImageWrapper = styled.div<{ $bgColor: string }>`
   height: 47px;
   background: ${(props) => props.$bgColor};
   border-radius: 50%;
+  cursor: pointer;
 `;
 
 const ProfileImage = styled.object`
@@ -176,10 +178,16 @@ const UserName = styled.p`
 const OnlineStatus = styled.p`
   ${(props) => props.theme.fonts.medium11};
   color: ${theme.colors.gray200};
+  cursor: default;
 `;
 
 const OnlineImage = styled(Image)`
   position: absolute;
   top: 1%;
   right: -11%;
+`;
+
+const ThreeDotsButton = styled.button`
+  width: 20px;
+  height: 20px;
 `;

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -49,16 +49,16 @@ const MessageList = (props: MessageListProps) => {
   const dispatch = useDispatch();
 
   const [messageList, setMessageList] = useState<ChatMessageDto[]>(
-    chatEnterData?.chatMessageListResponse.chatMessageDtoList || []
+    chatEnterData?.chatMessageListResponse.chatMessageList || []
   );
   const [isLoading, setIsLoading] = useState(false);
   const [cursor, setCursor] = useState<number | null>(
-    chatEnterData?.chatMessageListResponse.has_next
-      ? chatEnterData.chatMessageListResponse.next_cursor
+    chatEnterData?.chatMessageListResponse.hasNext
+      ? chatEnterData.chatMessageListResponse.nextCursor
       : null
   );
   const [hasMore, setHasMore] = useState<boolean>(
-    chatEnterData?.chatMessageListResponse.has_next
+    chatEnterData?.chatMessageListResponse.hasNext
   );
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   const [isBoardId, setIsBoardId] = useState(0);
@@ -182,17 +182,14 @@ const MessageList = (props: MessageListProps) => {
       const previousScrollHeight = chatElement.scrollHeight;
 
       const data = await getChatList({ uuid: chatEnterData.uuid, cursor });
-      const { chatMessageDtoList, next_cursor, has_next } =
+      const { chatMessageList, nextCursor, hasNext } =
         data.data.chatMessageList;
 
       // 기존 메시지 목록에 새로운 메시지 추가
-      setMessageList((prevMessages) => [
-        ...chatMessageDtoList,
-        ...prevMessages,
-      ]);
+      setMessageList((prevMessages) => [...chatMessageList, ...prevMessages]);
 
-      setCursor(next_cursor);
-      setHasMore(has_next);
+      setCursor(nextCursor);
+      setHasMore(hasNext);
 
       requestAnimationFrame(() => {
         // 새로운 메시지가 추가된 후의 스크롤 높이 차이 계산

--- a/src/components/common/PositionCategory.tsx
+++ b/src/components/common/PositionCategory.tsx
@@ -7,19 +7,20 @@ import Mid from "../../../public/assets/icons/position_mid_unclicked.svg";
 import OndDeal from "../../../public/assets/icons/position_one_deal_unclicked.svg";
 import Supporter from "../../../public/assets/icons/position_supporter_unclicked.svg";
 import React, { useEffect } from "react";
+import { Position } from "@/types/position/position";
 
 interface PositionComponentProps {
   onClose: () => void;
   boxName?: string;
-  onSelect: (positionId: number) => void;
+  onSelect: (positionName: Position) => void;
 }
 
 const PositionCategory = (props: PositionComponentProps) => {
   const { onClose, onSelect } = props;
   const boxRef = React.useRef<HTMLDivElement>(null);
 
-  const handlePositionCategory = (positionId: number) => {
-    onSelect(positionId);
+  const handlePositionCategory = (positionName: Position) => {
+    onSelect(positionName);
     onClose();
   };
 
@@ -39,22 +40,22 @@ const PositionCategory = (props: PositionComponentProps) => {
   return (
     <Wrapper>
       <Box ref={boxRef}>
-        <AllButton onClick={() => handlePositionCategory(0)}>
+        <AllButton onClick={() => handlePositionCategory("ANY")}>
           <All />
         </AllButton>
-        <TopButton onClick={() => handlePositionCategory(1)}>
+        <TopButton onClick={() => handlePositionCategory("TOP")}>
           <Top />
         </TopButton>
-        <JungleButton onClick={() => handlePositionCategory(2)}>
+        <JungleButton onClick={() => handlePositionCategory("JUNGLE")}>
           <Jungle />
         </JungleButton>
-        <MidButton onClick={() => handlePositionCategory(3)}>
+        <MidButton onClick={() => handlePositionCategory("MID")}>
           <Mid />
         </MidButton>
-        <OneDealButton onClick={() => handlePositionCategory(4)}>
+        <OneDealButton onClick={() => handlePositionCategory("ADC")}>
           <OndDeal />
         </OneDealButton>
-        <SupporterButton onClick={() => handlePositionCategory(5)}>
+        <SupporterButton onClick={() => handlePositionCategory("SUP")}>
           <Supporter />
         </SupporterButton>
       </Box>

--- a/src/components/crBoard/PositionBox.tsx
+++ b/src/components/crBoard/PositionBox.tsx
@@ -32,6 +32,7 @@ const PositionBox = (props: PositionBoxProps) => {
     want: want,
   });
 
+  console.log("positionValue,", positionValue);
   useEffect(() => {
     setPositionValue({
       main: main ?? "ANY",
@@ -40,16 +41,16 @@ const PositionBox = (props: PositionBoxProps) => {
     });
   }, [main, sub, want]);
 
-  const handleCategoryButtonClick = (positionId: number) => {
+  const handleCategoryButtonClick = (positionName: PositionType) => {
     if (selectedBox) {
       setPositionValue((prevPositionValue) => ({
         ...prevPositionValue,
-        [selectedBox]: positionId,
+        [selectedBox]: "ANY",
       }));
       if (onPositionChange) {
         onPositionChange({
           ...positionValue,
-          [selectedBox]: positionId,
+          [selectedBox]: positionName,
         });
       }
     }

--- a/src/components/match/Profile.tsx
+++ b/src/components/match/Profile.tsx
@@ -37,6 +37,7 @@ import {
 import { deleteFriend } from "@/api/friend/delete";
 import { blockMember, unblockMember } from "@/api/block/block";
 import { Mike as MikeType } from "@/types/user/mike";
+import { Position as PositionType } from "@/types/position/position";
 
 type profileType = "normal" | "wind" | "other" | "me";
 
@@ -244,11 +245,11 @@ const Profile: React.FC<Profile> = ({
     }
   };
 
-  const handleCategoryButtonClick = (positionId: number) => {
+  const handleCategoryButtonClick = (positionName: PositionType) => {
     if (selectedBox) {
       const newPositionValue = {
         ...positionValue,
-        [selectedBox]: positionId,
+        [selectedBox]: positionName,
       };
       setPositionValue(newPositionValue);
       handlePositionChange(newPositionValue);

--- a/src/components/readBoard/ReadBoard.tsx
+++ b/src/components/readBoard/ReadBoard.tsx
@@ -40,6 +40,7 @@ import { AlertProps } from "@/interface/modal";
 import { useRouter } from "next/navigation";
 import {
   openChatRoom,
+  setChatEnterType,
   setChatRoomUuid,
   setErrorMessage,
 } from "@/redux/slices/chatSlice";
@@ -513,6 +514,7 @@ const ReadBoard = (props: ReadBoardProps) => {
         if (isPost) {
           dispatch(setChatRoomUuid(isPost.boardId));
           dispatch(openChatRoom());
+          dispatch(setChatEnterType(2)); // 게시글에서 채팅방 입장
         }
       } catch (error) {
         console.error(error);

--- a/src/interface/chat.ts
+++ b/src/interface/chat.ts
@@ -49,10 +49,10 @@ export interface ChatMessageDto {
 }
 
 export interface ChatMessageList {
-  chatMessageDtoList: ChatMessageDto[] | [];
-  list_size: number;
-  has_next: boolean;
-  next_cursor: number | null;
+  chatMessageList: ChatMessageDto[] | [];
+  listSize: number;
+  hasNext: boolean;
+  nextCursor: number | null;
 }
 
 interface System {

--- a/src/redux/slices/chatSlice.ts
+++ b/src/redux/slices/chatSlice.ts
@@ -4,6 +4,7 @@ interface ChatState {
     isChatOpen: boolean;
     isChatRoomOpen: boolean;
     isChatRoomUuid: string | number;
+    chatEnterType: number|null;
     memberId: number;
     onlineFriends: number[];
     unreadUuids: string[];
@@ -15,6 +16,7 @@ const initialState: ChatState = {
     isChatOpen: false,
     isChatRoomOpen: false,
     isChatRoomUuid: 0 || "",
+    chatEnterType: null,
     memberId: 0,
     onlineFriends: [],
     currentChatUuid: null,
@@ -23,55 +25,60 @@ const initialState: ChatState = {
 };
 
 const chatSlice = createSlice({
-    name: 'chat',
-    initialState,
-    reducers: {
-        openChat(state) {
-            state.isChatOpen = true;
-        },
-        closeChat(state) {
-            state.isChatOpen = false;
-        },
-        toggleChat(state) {
-            state.isChatOpen = !state.isChatOpen;
-        },
-        openChatRoom(state) {
-            state.isChatRoomOpen = true;
-        },
-        closeChatRoom(state) {
-            state.isChatRoomOpen = false;
-        },
-        setChatRoomUuid(state, action: PayloadAction<string | number>) {
-            state.isChatRoomUuid = action.payload;
-        },
-        setMemberId(state, action: PayloadAction<number>) {
-            state.memberId = action.payload;
-        },
-        setFriendOnline(state, action: PayloadAction<number | number[]>) {
-            if (Array.isArray(action.payload)) {
-                // 배열인 경우 전체를 업데이트
-                state.onlineFriends = action.payload;
-            } else {
-                // 개별 온라인 친구 id 추가
-                if (!state.onlineFriends.includes(action.payload)) {
-                    state.onlineFriends.push(action.payload);
-                }
-            }
-        },
-        setFriendOffline(state, action: PayloadAction<number>) {
-            // id를 배열에서 제거
-            state.onlineFriends = state.onlineFriends.filter(id => id !== action.payload);
-        },
-        setCurrentChatUuid(state, action: PayloadAction<string>) {
-            state.currentChatUuid = action.payload;
-        },
-        setUnreadUuid(state, action: PayloadAction<string[]>) {
-            state.unreadUuids = action.payload;
-        },
-        setErrorMessage(state, action: PayloadAction<string | null>) {
-            state.errorMessage = action.payload;
-        },
+  name: "chat",
+  initialState,
+  reducers: {
+    openChat(state) {
+      state.isChatOpen = true;
     },
+    closeChat(state) {
+      state.isChatOpen = false;
+    },
+    toggleChat(state) {
+      state.isChatOpen = !state.isChatOpen;
+    },
+    openChatRoom(state) {
+      state.isChatRoomOpen = true;
+    },
+    closeChatRoom(state) {
+      state.isChatRoomOpen = false;
+    },
+    setChatRoomUuid(state, action: PayloadAction<string | number>) {
+      state.isChatRoomUuid = action.payload;
+    },
+    setChatEnterType(state, action: PayloadAction<number|null>) {
+      state.chatEnterType = action.payload;
+    },
+    setMemberId(state, action: PayloadAction<number>) {
+      state.memberId = action.payload;
+    },
+    setFriendOnline(state, action: PayloadAction<number | number[]>) {
+      if (Array.isArray(action.payload)) {
+        // 배열인 경우 전체를 업데이트
+        state.onlineFriends = action.payload;
+      } else {
+        // 개별 온라인 친구 id 추가
+        if (!state.onlineFriends.includes(action.payload)) {
+          state.onlineFriends.push(action.payload);
+        }
+      }
+    },
+    setFriendOffline(state, action: PayloadAction<number>) {
+      // id를 배열에서 제거
+      state.onlineFriends = state.onlineFriends.filter(
+        (id) => id !== action.payload
+      );
+    },
+    setCurrentChatUuid(state, action: PayloadAction<string>) {
+      state.currentChatUuid = action.payload;
+    },
+    setUnreadUuid(state, action: PayloadAction<string[]>) {
+      state.unreadUuids = action.payload;
+    },
+    setErrorMessage(state, action: PayloadAction<string | null>) {
+      state.errorMessage = action.payload;
+    },
+  },
 });
 
 export const {
@@ -81,6 +88,7 @@ export const {
     openChatRoom,
     closeChatRoom,
     setChatRoomUuid,
+    setChatEnterType,
     setMemberId,
     setFriendOnline,
     setFriendOffline,


### PR DESCRIPTION
## 연관 이슈

close #184

<br/>

## 📁 작업 내용

채팅내역 불러오기 오류 해결 및 채팅방 내에서 채팅창 이동하기

- 채팅내용 불러오기 API 응답 객체명 수정
- 채팅방 내부에서 채팅방 이동 기능 적용
- 채팅방 내부 헤더 cursor 관련 처리 및 케밥 버튼 영역 늘림

<br/>

- 채팅방 진입 타입 (기존 `apiType` → 전역 상태 `chatEnterType` ) 수정
- 게시판이나 매칭 등에서 채팅창을 그저 띄우는 것이 아닌, 특정 채팅방 화면을 띄워줄 경우에 기존에는 `ChayLayout`을 렌더링 해주었지만, `Layout`을 렌더링하고 Layout 컴포넌트에서 `uuid`가 있을 때  `ChayLayout`을 렌더링하도록 함.
 _(그래야 이렇게 특정 채팅방으로 바로 진입할 경우에도 채팅창 Drag가 유효하기 때문!)_
- `PositionBox` 선택 시 id (number)가 아닌 name (string)으로 설정되도록 수정

<br/>

## 🖥 구현 결과 (선택)

https://github.com/user-attachments/assets/c3eb7c1f-bed3-4603-8069-b45bafefdcb9



<br/>


## 📁 기타 사항

- 기존에 **채팅방 내부**에서 **채팅 내용이 불러오지 않는 오류**가 있었습니다.
원인은, 채팅 관련 API가 v2로 바뀌었는데 그러면서 `has_next` → `hasNext` 등으로 바뀐 응답값의 객체명들이 제대로 반영되지 않아 발생했던 것이었습니다. 따라서 해당 내용 변경을 통해 채팅 내용을 성공적으로 불러왔습니다. (6852b99845a8902a50cb159b3006e69fa9f00da6)
- 채팅방을 이동하는 기능을 이전 PR #169 에서 구현하였는데, 채팅방 내부에서 확인해보니 **채팅방 안에서는 이동이 적용되지 않는 것**을 확인했습니다. 따라서 position 정보를 상위로 올려 `ChatLayout.tsx`를 감싸고, hadleDragStart 함수를 ChatLayout 내부 HeaderWrapper로 props 하여 채팅방 내부에서도 이동이 적용되도록 하였습니다. (2e4c61d725c7b03f8fdc6321d2dd17413df4f519)
- 마지막으로, 채팅방 내부에서 케밥 버튼의 선택 영역이 작아 불편해 button 영역 크기를 늘렸고, 닉네임이나 프로필 이미지 등 채팅창 헤더 내에서 클릭 이벤트가 발생하는 부분은 cursor가 move로 동작하지 않도록 따로 cursor: pointer로 저장해주었습니다. (0b8f1e66145bc3d9be1ff60cd1231eb035588ac5)

<br/>

- 배포 이후 커밋에 대한 설명은 위에 작업 내용에 적어둡니다!
