### PR TITLE
[Feat] 찾는 포지션 설정 방식 변경

### DIFF
--- a/src/api/manner/manner.ts
+++ b/src/api/manner/manner.ts
@@ -4,7 +4,7 @@ import {
   MemberMannerLevelResponse,
   MemberPositiveNegativeMannerResponse,
 } from "@/types/api/manner/manner";
-import { AuthAxios } from "./auth";
+import { AuthAxios } from "../auth";
 
 interface MannerInterface {
   memberId: number;
@@ -71,7 +71,9 @@ export const postMannerValue = async (
   try {
     const response = await AuthAxios.post(
       `/api/v2/manner/positive/${params.memberId}`,
-      params.mannerKeywordIdList
+      {
+        mannerKeywordIdList: params.mannerKeywordIdList
+      }
     );
     return response.data;
   } catch (error) {
@@ -86,7 +88,9 @@ export const postBadMannerValue = async (
   try {
     const response = await AuthAxios.post(
       `/api/v2/manner/negative/${params.memberId}`,
-      params.mannerKeywordIdList
+      {
+        mannerKeywordIdList: params.mannerKeywordIdList
+      }
     );
     return response.data;
   } catch (error) {
@@ -102,7 +106,9 @@ export const editManners = async ({
   try {
     const response = await AuthAxios.put(
       `/api/v2/manner/${mannerId}`,
-      mannerKeywordIdList
+      {
+        mannerKeywordIdList: mannerKeywordIdList
+      }
     );
     return response.data;
   } catch (error) {

--- a/src/app/mypage/review/page.tsx
+++ b/src/app/mypage/review/page.tsx
@@ -8,7 +8,10 @@ import { useEffect, useState } from "react";
 import { Manner } from "@/components/user/UserProfile";
 import { useSelector } from "react-redux";
 import { RootState } from "@/redux/store";
-import { getMemberMannerKeyword, getMemberMannerLevel } from "@/api/manner";
+import {
+  getMemberMannerKeyword,
+  getMemberMannerLevel,
+} from "@/api/manner/manner";
 
 const MyReviewPage = () => {
   const myId = useSelector((state: RootState) => state.user.id);

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { getMemberMannerKeyword, getMemberMannerLevel } from "@/api/manner";
+import {
+  getMemberMannerKeyword,
+  getMemberMannerLevel,
+} from "@/api/manner/manner";
 import { getOtherProfile } from "@/api/user/profile/get";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import BlindProfile from "@/components/user/BlindProfile";

--- a/src/components/board/Table.tsx
+++ b/src/components/board/Table.tsx
@@ -212,15 +212,24 @@ const Table = (props: TableProps) => {
                     />
                   </Fourth>
                   <Fifth className="table_width">
-                    {data.wantP.map((posi, i) => (
+                    {data.wantP?.length > 0 ? (
+                      data.wantP.map((posi, i) => (
+                        <Image
+                          key={`${posi}-${i}`}
+                          src={setPositionImg(posi || "ANY")}
+                          width={35}
+                          height={28}
+                          alt="찾는 포지션"
+                        />
+                      ))
+                    ) : (
                       <Image
-                        key={`${posi}-${i}`}
-                        src={setPositionImg(posi)}
+                        src={setPositionImg("ANY")}
                         width={35}
                         height={28}
                         alt="찾는 포지션"
                       />
-                    ))}
+                    )}
                   </Fifth>
                   <Sixth className="table_width">
                     <Champion

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -27,7 +27,7 @@ import {
   getMannerValues,
   postBadMannerValue,
   postMannerValue,
-} from "@/api/manner";
+} from "@/api/manner/manner";
 import { Mannerstatus } from "@/interface/manner";
 import ConfirmModal from "../common/ConfirmModal";
 import FormModal from "../common/FormModal";

--- a/src/components/chat/Layout.tsx
+++ b/src/components/chat/Layout.tsx
@@ -21,7 +21,7 @@ import {
   getMannerValues,
   postBadMannerValue,
   postMannerValue,
-} from "@/api/manner";
+} from "@/api/manner/manner";
 import ConfirmModal from "../common/ConfirmModal";
 import { leaveChatroom } from "@/api/chat/chat";
 import { setCloseModal, setOpenModal } from "@/redux/slices/modalSlice";

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -255,7 +255,7 @@ const Button = styled.button<{ $type: string | undefined }>`
     &:active,
     &:focus {
       color: ${theme.colors.violet600};
-      background: ${theme.colors.gray500};
+      background: ${theme.colors.gray100};
       border-radius: 0 0 0 20px;
     }
   }
@@ -265,7 +265,7 @@ const Button = styled.button<{ $type: string | undefined }>`
     &:active,
     &:focus {
       color: ${theme.colors.violet600};
-      background: ${theme.colors.gray500};
+      background: ${theme.colors.gray100};
       border-radius: 0 0 20px 0;
     }
   }
@@ -275,7 +275,7 @@ const Button = styled.button<{ $type: string | undefined }>`
     &:active,
     &:focus {
       color: ${theme.colors.violet600};
-      background: ${theme.colors.gray500};
+      background: ${theme.colors.gray100};
       border-radius: 0 0 20px 20px;
     }
   }

--- a/src/components/common/MannerLevelBox.tsx
+++ b/src/components/common/MannerLevelBox.tsx
@@ -3,7 +3,7 @@ import { theme } from "@/styles/theme";
 import { BAD_MANNER_TYPES, MANNER_TYPES } from "@/constants/mannerLevel";
 import { useEffect, useState } from "react";
 import { MannerKeywords } from "@/interface/manner";
-import { getMemberMannerKeyword } from "@/api/manner";
+import { getMemberMannerKeyword } from "@/api/manner/manner";
 
 interface MannerLevelBoxProps {
   memberId: number;

--- a/src/components/common/PositionCategory.tsx
+++ b/src/components/common/PositionCategory.tsx
@@ -13,22 +13,46 @@ import Supporter from "../../../public/assets/images/position/position_supporter
 
 interface PositionComponentProps {
   selectedBox?: PositionType | null;
-  value?: Position | null;
-  onSelect: (positionName: Position | null) => void;
+  value?: Position | (Position | null)[];
+  onSelect: (selectedValues: Position | (Position | null)[]) => void;
   onClose: () => void;
 }
 
 const PositionCategory = (props: PositionComponentProps) => {
-  const { selectedBox, value, onSelect, onClose } = props;
+  const { selectedBox, value = [], onSelect, onClose } = props;
   const boxRef = React.useRef<HTMLDivElement>(null);
 
   const handlePositionCategory = (positionName: Position | null) => {
-    if (value === positionName) {
-      // 현재 선택 포지션 클릭시 초기화
-      onSelect(null);
+    console.log("positionName", positionName);
+
+    let updatedValues: Position | (Position | null)[];
+
+    if (selectedBox === "want") {
+      // 찾는 포지션 (want) → 최대 2개 선택 가능
+      let wantArray = Array.isArray(value) ? [...value] : [];
+
+      // 이미 선택된 경우 → 제거
+      if (wantArray.includes(positionName)) {
+        updatedValues = wantArray.filter((v) => v !== positionName);
+      } else if (wantArray.length < 2 || wantArray.includes(null)) {
+        // 최대 2개 선택 가능
+        const firstEmptyIndex = wantArray.indexOf(null);
+        if (firstEmptyIndex !== -1) {
+          wantArray[firstEmptyIndex] = positionName;
+        } else {
+          wantArray.push(positionName);
+        }
+        updatedValues = wantArray.slice(0, 2);
+      } else {
+        updatedValues = wantArray;
+      }
     } else {
-      onSelect(positionName);
+      // 주/부 포지션 (main, sub) → 하나만 선택 가능
+      updatedValues = positionName || "ANY";
     }
+
+    console.log(updatedValues);
+    onSelect(updatedValues);
     onClose();
   };
 
@@ -45,11 +69,12 @@ const PositionCategory = (props: PositionComponentProps) => {
     };
   }, [onClose]);
 
-  const getImageSrc = (position: Position | null) => {
-    const positionData = POSITION.find((p) => p.key === position);
-    if (!positionData || !positionData.image) return "";
+  const getImageSrc = (position: Position) => {
+    const positionData =
+      POSITION.find((p) => p.key === position) || POSITION[1];
+
     return `/assets/images/position/position_${positionData.image}_${
-      value === position ? "purple" : "unclicked"
+      value.includes(position) ? "purple" : "unclicked"
     }.svg`;
   };
 
@@ -72,21 +97,18 @@ const PositionCategory = (props: PositionComponentProps) => {
     }
   };
 
-  const positionList =
-    selectedBox === "want1" || selectedBox === "want2"
-      ? POSITION.slice(2)
-      : POSITION.slice(1);
+  const positionList = selectedBox === "want" ? POSITION.slice(1) : POSITION;
 
   return (
     <Wrapper>
-      <Box ref={boxRef}>
+      <Box $isWant={selectedBox === "want"} ref={boxRef}>
         {positionList.map((pos) => (
           <StyledButton
             key={pos.id}
-            posKey={pos.key || null}
+            posKey={pos.key}
             onClick={() => handlePositionCategory(pos.key)}
           >
-            {value === pos.key ? (
+            {value.includes(pos.key) ? (
               <Image
                 src={getImageSrc(pos.key)}
                 alt={pos.key || "선택"}
@@ -113,11 +135,11 @@ const Wrapper = styled.div`
   z-index: 10;
 `;
 
-const Box = styled.div`
+const Box = styled.div<{ $isWant: boolean }>`
   display: flex;
   align-items: center;
   column-gap: 50px;
-  width: 482px;
+  width: ${({ $isWant }) => ($isWant ? "410px" : "482px")};
   padding: 18px 27px;
   background: ${theme.colors.gray900};
   border-radius: 16.3px;
@@ -133,7 +155,7 @@ const Box = styled.div`
   }
 `;
 
-const StyledButton = styled.button<{ posKey: Position | null }>`
+const StyledButton = styled.button<{ posKey: Position }>`
   background: none;
   border: none;
   padding: 0;

--- a/src/components/common/PositionCategory.tsx
+++ b/src/components/common/PositionCategory.tsx
@@ -1,26 +1,34 @@
 import { theme } from "@/styles/theme";
 import styled from "styled-components";
+import React, { useEffect } from "react";
+import { Position, PositionType } from "@/types/position/position";
+import Image from "next/image";
+import { POSITION } from "@/constants/position";
 import All from "../../../public/assets/images/position/position_all_unclicked.svg";
 import Top from "../../../public/assets/images/position/position_top_unclicked.svg";
 import Jungle from "../../../public/assets/images/position/position_jungle_unclicked.svg";
 import Mid from "../../../public/assets/images/position/position_mid_unclicked.svg";
-import OndDeal from "../../../public/assets/images/position/position_one_deal_unclicked.svg";
+import OneDeal from "../../../public/assets/images/position/position_one_deal_unclicked.svg";
 import Supporter from "../../../public/assets/images/position/position_supporter_unclicked.svg";
-import React, { useEffect } from "react";
-import { Position } from "@/types/position/position";
 
 interface PositionComponentProps {
+  selectedBox?: PositionType | null;
+  value?: Position | null;
+  onSelect: (positionName: Position | null) => void;
   onClose: () => void;
-  boxName?: string;
-  onSelect: (positionName: Position) => void;
 }
 
 const PositionCategory = (props: PositionComponentProps) => {
-  const { onClose, onSelect } = props;
+  const { selectedBox, value, onSelect, onClose } = props;
   const boxRef = React.useRef<HTMLDivElement>(null);
 
-  const handlePositionCategory = (positionName: Position) => {
-    onSelect(positionName);
+  const handlePositionCategory = (positionName: Position | null) => {
+    if (value === positionName) {
+      // 현재 선택 포지션 클릭시 초기화
+      onSelect(null);
+    } else {
+      onSelect(positionName);
+    }
     onClose();
   };
 
@@ -37,27 +45,59 @@ const PositionCategory = (props: PositionComponentProps) => {
     };
   }, [onClose]);
 
+  const getImageSrc = (position: Position | null) => {
+    const positionData = POSITION.find((p) => p.key === position);
+    if (!positionData || !positionData.image) return "";
+    return `/assets/images/position/position_${positionData.image}_${
+      value === position ? "purple" : "unclicked"
+    }.svg`;
+  };
+
+  const getSvgComponent = (position: Position | null) => {
+    switch (position) {
+      case "ANY":
+        return <All />;
+      case "TOP":
+        return <Top />;
+      case "JUNGLE":
+        return <Jungle />;
+      case "MID":
+        return <Mid />;
+      case "ADC":
+        return <OneDeal />;
+      case "SUP":
+        return <Supporter />;
+      default:
+        return <All />;
+    }
+  };
+
+  const positionList =
+    selectedBox === "want1" || selectedBox === "want2"
+      ? POSITION.slice(2)
+      : POSITION.slice(1);
+
   return (
     <Wrapper>
       <Box ref={boxRef}>
-        <AllButton onClick={() => handlePositionCategory("ANY")}>
-          <All />
-        </AllButton>
-        <TopButton onClick={() => handlePositionCategory("TOP")}>
-          <Top />
-        </TopButton>
-        <JungleButton onClick={() => handlePositionCategory("JUNGLE")}>
-          <Jungle />
-        </JungleButton>
-        <MidButton onClick={() => handlePositionCategory("MID")}>
-          <Mid />
-        </MidButton>
-        <OneDealButton onClick={() => handlePositionCategory("ADC")}>
-          <OndDeal />
-        </OneDealButton>
-        <SupporterButton onClick={() => handlePositionCategory("SUP")}>
-          <Supporter />
-        </SupporterButton>
+        {positionList.map((pos) => (
+          <StyledButton
+            key={pos.id}
+            posKey={pos.key || null}
+            onClick={() => handlePositionCategory(pos.key)}
+          >
+            {value === pos.key ? (
+              <Image
+                src={getImageSrc(pos.key)}
+                alt={pos.key || "선택"}
+                width={35}
+                height={35}
+              />
+            ) : (
+              getSvgComponent(pos.key)
+            )}
+          </StyledButton>
+        ))}
       </Box>
     </Wrapper>
   );
@@ -71,18 +111,6 @@ const Wrapper = styled.div`
   top: 100px;
   left: calc(50% - 35px);
   z-index: 10;
-  &.main {
-    top: 47%;
-    left: 10%;
-  }
-  &.sub {
-    top: 47%;
-    left: 28.5%;
-  }
-  &.want {
-    top: 47%;
-    left: 65.5%;
-  }
 `;
 
 const Box = styled.div`
@@ -105,62 +133,42 @@ const Box = styled.div`
   }
 `;
 
-const AllButton = styled.button`
-  &:hover path {
-    stroke: ${theme.colors.violet200};
-  }
-  &:active,
-  &:focus path {
-    stroke: ${theme.colors.violet600};
-  }
-`;
+const StyledButton = styled.button<{ posKey: Position | null }>`
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
 
-const TopButton = styled.button`
-  &:hover path:first-child {
-    fill: ${theme.colors.violet200};
-  }
-  &:active,
-  &:focus path:first-child {
-    fill: ${theme.colors.violet600};
-  }
-`;
+  ${({ posKey }) =>
+    (posKey === "ANY" || posKey === "JUNGLE" || posKey === "SUP") &&
+    `
+      &:hover path {
+        fill: ${theme.colors.violet200};
+      }
+      &:active, &:focus path {
+        fill: ${theme.colors.violet600};
+      }
+  `}
 
-const JungleButton = styled.button`
-  &:hover path {
-    fill: ${theme.colors.violet200};
-  }
-  &:active,
-  &:focus path {
-    fill: ${theme.colors.violet600};
-  }
-`;
+  ${({ posKey }) =>
+    posKey === "TOP" &&
+    `
+      &:hover path:first-child {
+        fill: ${theme.colors.violet200};
+      }
+      &:active, &:focus path:first-child {
+        fill: ${theme.colors.violet600};
+      }
+  `}
 
-const MidButton = styled.button`
-  &:hover path:nth-child(2) {
-    fill: ${theme.colors.violet200};
-  }
-  &:active,
-  &:focus path:nth-child(2) {
-    fill: ${theme.colors.violet600};
-  }
-`;
-
-const OneDealButton = styled.button`
-  &:hover path:nth-child(2) {
-    fill: ${theme.colors.violet200};
-  }
-  &:active,
-  &:focus path:nth-child(2) {
-    fill: ${theme.colors.violet600};
-  }
-`;
-
-const SupporterButton = styled.button`
-  &:hover path {
-    fill: ${theme.colors.violet200};
-  }
-  &:active,
-  &:focus path {
-    fill: ${theme.colors.violet600};
-  }
+  ${({ posKey }) =>
+    (posKey === "MID" || posKey === "ADC") &&
+    `
+      &:hover path:nth-child(2) {
+        fill: ${theme.colors.violet200};
+      }
+      &:active, &:focus path:nth-child(2) {
+        fill: ${theme.colors.violet600};
+      }
+  `}
 `;

--- a/src/components/crBoard/PositionBox.tsx
+++ b/src/components/crBoard/PositionBox.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import PositionCategory from "../common/PositionCategory";
 import { Position, PositionType } from "@/types/position/position";
 import { theme } from "@/styles/theme";
@@ -11,15 +11,15 @@ type Status = "reading" | "posting";
 interface PositionBoxProps {
   status?: Status;
   onPositionChange?: (newPositionValue: PositionState) => void;
-  main: Position;
-  sub: Position;
-  want: (Position | null)[] | undefined;
+  main: Position | null;
+  sub: Position | null;
+  want: (Position | null)[] | null;
 }
 
 export interface PositionState {
   main: Position;
   sub: Position;
-  want: (Position | null)[] | undefined | null;
+  want: (Position | null)[] | null;
 }
 
 const PositionBox = (props: PositionBoxProps) => {
@@ -27,18 +27,10 @@ const PositionBox = (props: PositionBoxProps) => {
   const [selectedBox, setSelectedBox] = useState<PositionType | null>(null);
   const [openPosition, setOpenPosition] = useState<PositionType | null>(null);
   const [positionValue, setPositionValue] = useState<PositionState>({
-    main: main,
-    sub: sub,
+    main: main || "ANY",
+    sub: sub || "ANY",
     want: want ?? [],
   });
-
-  useEffect(() => {
-    setPositionValue({
-      main: main ?? "ANY",
-      sub: sub ?? "ANY",
-      want: want ?? [],
-    });
-  }, [main, sub, want]);
 
   /* 포지션 선택  */
   const handleCategoryButtonClick = (
@@ -142,14 +134,16 @@ const PositionBox = (props: PositionBoxProps) => {
             height={34}
             alt="첫 번째 찾는 포지션"
           />
-          <StyledImage
-            $status={status}
-            onClick={() => handleBoxClick("want")}
-            src={handlePositionImgSet(positionValue.want?.[1])}
-            width={35}
-            height={34}
-            alt="두 번째 찾는 포지션"
-          />
+          {(positionValue.want?.[1] || status === "posting") && (
+            <StyledImage
+              $status={status}
+              onClick={() => handleBoxClick("want")}
+              src={handlePositionImgSet(positionValue.want?.[1])}
+              width={35}
+              height={34}
+              alt="두 번째 찾는 포지션"
+            />
+          )}
           {openPosition === "want" && (
             <PositionCategory
               selectedBox={selectedBox}

--- a/src/components/crBoard/PositionBox.tsx
+++ b/src/components/crBoard/PositionBox.tsx
@@ -11,14 +11,14 @@ type Status = "reading" | "posting";
 interface PositionBoxProps {
   status?: Status;
   onPositionChange?: (newPositionValue: PositionState) => void;
-  main: Position | undefined;
-  sub: Position | undefined;
+  main: Position;
+  sub: Position;
   want: (Position | null)[] | undefined;
 }
 
 export interface PositionState {
-  main: Position | undefined;
-  sub: Position | undefined;
+  main: Position;
+  sub: Position;
   want: (Position | null)[] | undefined | null;
 }
 
@@ -29,51 +29,48 @@ const PositionBox = (props: PositionBoxProps) => {
   const [positionValue, setPositionValue] = useState<PositionState>({
     main: main,
     sub: sub,
-    want: want ?? [null, null],
+    want: want ?? [],
   });
 
   useEffect(() => {
-    let finalWant: (Position | null)[] = want ?? [null, null];
-    if (finalWant.length < 2) {
-      finalWant = [finalWant[0] ?? null, null];
-    } else if (finalWant.length > 2) {
-      finalWant = [finalWant[0], finalWant[1]];
-    }
-
     setPositionValue({
       main: main ?? "ANY",
       sub: sub ?? "ANY",
-      want: finalWant,
+      want: want ?? [],
     });
   }, [main, sub, want]);
 
   /* 포지션 선택  */
-  const handleCategoryButtonClick = (positionName: Position | null) => {
-    if (!selectedBox) return;
+  const handleCategoryButtonClick = (
+    selectedValues: Position | (Position | null)[]
+  ) => {
+    setPositionValue((prev) => {
+      let updated;
 
-    // 포지션 박스 타입별 처리
-    if (selectedBox === "main" || selectedBox === "sub") {
-      setPositionValue((prev) => {
-        const updated = { ...prev, [selectedBox]: positionName };
-        onPositionChange && onPositionChange(updated);
-        return updated;
-      });
-    } else {
-      setPositionValue((prev) => {
-        const newWant = [...(prev.want ?? [null, null])];
-        if (selectedBox === "want1") {
-          newWant[0] = positionName;
-        } else if (selectedBox === "want2") {
-          newWant[1] = positionName;
-        }
-        const updated = { ...prev, want: newWant };
-        onPositionChange && onPositionChange(updated);
-        return updated;
-      });
-    }
+      if (selectedBox === "want") {
+        // `want`는 배열 형태로 유지 (최대 2개 선택 가능)
+        updated = {
+          ...prev,
+          want: Array.isArray(selectedValues)
+            ? selectedValues
+            : [selectedValues],
+        };
+        console.log(updated);
+      } else {
+        // `main`과 `sub`은 단일 값만 저장
+        updated = {
+          ...prev,
+          [selectedBox as "main" | "sub"]: selectedValues as Position,
+        };
+      }
+
+      onPositionChange && onPositionChange(updated);
+      return updated;
+    });
   };
 
   const handlePositionImgSet = (positionId: Position | undefined | null) => {
+    // console.log("handlePositionImgSet", positionId);
     const positionData = POSITION.find((p) => p.key === positionId);
     if (!positionData || !positionData.image)
       return "/assets/icons/bottom_caution.svg";
@@ -139,33 +136,25 @@ const PositionBox = (props: PositionBoxProps) => {
         <WantPWrapper>
           <StyledImage
             $status={status}
-            onClick={() => handleBoxClick("want1")}
+            onClick={() => handleBoxClick("want")}
             src={handlePositionImgSet(positionValue.want?.[0])}
             width={35}
             height={34}
             alt="첫 번째 찾는 포지션"
           />
-          {openPosition === "want1" && (
-            <PositionCategory
-              selectedBox={selectedBox}
-              onClose={closePosition}
-              value={positionValue.want?.[0]}
-              onSelect={handleCategoryButtonClick}
-            />
-          )}
           <StyledImage
             $status={status}
-            onClick={() => handleBoxClick("want2")}
+            onClick={() => handleBoxClick("want")}
             src={handlePositionImgSet(positionValue.want?.[1])}
             width={35}
             height={34}
             alt="두 번째 찾는 포지션"
           />
-          {openPosition === "want2" && (
+          {openPosition === "want" && (
             <PositionCategory
-              selectedBox={"want2"}
+              selectedBox={selectedBox}
               onClose={closePosition}
-              value={positionValue.want?.[1]}
+              value={positionValue.want || []}
               onSelect={handleCategoryButtonClick}
             />
           )}

--- a/src/components/crBoard/PositionBox.tsx
+++ b/src/components/crBoard/PositionBox.tsx
@@ -2,54 +2,41 @@ import styled from "styled-components";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 import PositionCategory from "../common/PositionCategory";
-import { Position as PositionType } from "@/types/position/position";
+import { Position, PositionType } from "@/types/position/position";
 import { theme } from "@/styles/theme";
+import { POSITION } from "@/constants/position";
 
 type Status = "reading" | "posting";
 
 interface PositionBoxProps {
   status?: Status;
   onPositionChange?: (newPositionValue: PositionState) => void;
-  main: PositionType | undefined;
-  sub: PositionType | undefined;
-  want: PositionType[] | undefined;
+  main: Position | undefined;
+  sub: Position | undefined;
+  want: (Position | null)[] | undefined;
 }
 
-type Position = "main" | "sub" | "want1" | "want2";
-
 export interface PositionState {
-  main: PositionType | undefined;
-  sub: PositionType | undefined;
-  want: PositionType[] | undefined;
+  main: Position | undefined;
+  sub: Position | undefined;
+  want: (Position | null)[] | undefined | null;
 }
 
 const PositionBox = (props: PositionBoxProps) => {
   const { status, onPositionChange, main, sub, want } = props;
-  const [selectedBox, setSelectedBox] = useState("");
-  const [openPosition, setOpenPosition] = useState<Position | null>(null);
+  const [selectedBox, setSelectedBox] = useState<PositionType | null>(null);
+  const [openPosition, setOpenPosition] = useState<PositionType | null>(null);
   const [positionValue, setPositionValue] = useState<PositionState>({
     main: main,
     sub: sub,
-    want: want,
+    want: want ?? [null, null],
   });
 
-  // useEffect(() => {
-  //   setPositionValue({
-  //     main: main ?? "ANY",
-  //     sub: sub ?? "ANY",
-  //     want: want ?? ["ANY"],
-  //   });
-  //   console.log("positionValue,", positionValue);
-  // }, [main, sub, want]);
-
-  // 3) 초기 마운트 시 want가 없거나 길이가 2 미만이면 ["ANY", "ANY"]로 맞춤
   useEffect(() => {
-    // (예) 부모에서 want를 ["TOP"]만 넘기거나 undefined로 넘길 수 있으므로 보정
-    let finalWant = want ?? ["ANY", "ANY"];
+    let finalWant: (Position | null)[] = want ?? [null, null];
     if (finalWant.length < 2) {
-      finalWant = [finalWant[0] ?? "ANY", "ANY"];
+      finalWant = [finalWant[0] ?? null, null];
     } else if (finalWant.length > 2) {
-      // 혹시 2개 이상 넘기면 앞의 2개만 사용
       finalWant = [finalWant[0], finalWant[1]];
     }
 
@@ -60,34 +47,20 @@ const PositionBox = (props: PositionBoxProps) => {
     });
   }, [main, sub, want]);
 
-  // 4) 포지션 선택 로직
-  const handleCategoryButtonClick = (positionName: PositionType) => {
-    // if (selectedBox) {
-    //   setPositionValue((prevPositionValue) => ({
-    //     ...prevPositionValue,
-    //     [selectedBox]: "ANY",
-    //   }));
-    //   if (onPositionChange) {
-    //     onPositionChange({
-    //       ...positionValue,
-    //       [selectedBox]: positionName,
-    //     });
-    //   }
-    // }
+  /* 포지션 선택  */
+  const handleCategoryButtonClick = (positionName: Position | null) => {
     if (!selectedBox) return;
 
-    // main / sub / want1 / want2 중 어떤 박스가 선택되었는지 분기
+    // 포지션 박스 타입별 처리
     if (selectedBox === "main" || selectedBox === "sub") {
-      // main, sub는 단일 값
       setPositionValue((prev) => {
         const updated = { ...prev, [selectedBox]: positionName };
         onPositionChange && onPositionChange(updated);
         return updated;
       });
     } else {
-      // want1, want2는 배열의 특정 인덱스 업데이트
       setPositionValue((prev) => {
-        const newWant = [...(prev.want ?? ["ANY", "ANY"])];
+        const newWant = [...(prev.want ?? [null, null])];
         if (selectedBox === "want1") {
           newWant[0] = positionName;
         } else if (selectedBox === "want2") {
@@ -100,26 +73,14 @@ const PositionBox = (props: PositionBoxProps) => {
     }
   };
 
-  const handlePositionImgSet = (positionId: PositionType | undefined) => {
-    switch (positionId) {
-      case "ANY":
-        return "/assets/images/position/position_all_purple.svg";
-      case "TOP":
-        return "/assets/images/position/position_top_purple.svg";
-      case "JUNGLE":
-        return "/assets/images/position/position_jungle_purple.svg";
-      case "MID":
-        return "/assets/images/position/position_mid_purple.svg";
-      case "ADC":
-        return "/assets/images/position/position_one_deal_purple.svg";
-      case "SUP":
-        return "/assets/images/position/position_supporter_purple.svg";
-      default:
-        return "/assets/images/position/position_all_purple.svg";
-    }
+  const handlePositionImgSet = (positionId: Position | undefined | null) => {
+    const positionData = POSITION.find((p) => p.key === positionId);
+    if (!positionData || !positionData.image)
+      return "/assets/icons/bottom_caution.svg";
+    return `/assets/images/position/position_${positionData.image}_purple.svg`;
   };
 
-  const handleBoxClick = (position: Position) => {
+  const handleBoxClick = (position: PositionType) => {
     if (status === "reading") return;
     setOpenPosition((prevPosition) =>
       prevPosition === position ? null : position
@@ -146,8 +107,9 @@ const PositionBox = (props: PositionBoxProps) => {
           />
           {openPosition === "main" && (
             <PositionCategory
+              selectedBox={selectedBox}
               onClose={closePosition}
-              boxName={selectedBox}
+              value={positionValue.main}
               onSelect={handleCategoryButtonClick}
             />
           )}
@@ -164,8 +126,9 @@ const PositionBox = (props: PositionBoxProps) => {
           />
           {openPosition === "sub" && (
             <PositionCategory
+              selectedBox={selectedBox}
               onClose={closePosition}
-              boxName={selectedBox}
+              value={positionValue.sub}
               onSelect={handleCategoryButtonClick}
             />
           )}
@@ -184,13 +147,12 @@ const PositionBox = (props: PositionBoxProps) => {
           />
           {openPosition === "want1" && (
             <PositionCategory
+              selectedBox={selectedBox}
               onClose={closePosition}
-              boxName={selectedBox}
+              value={positionValue.want?.[0]}
               onSelect={handleCategoryButtonClick}
             />
           )}
-
-          {/* 두 번째 want 포지션 */}
           <StyledImage
             $status={status}
             onClick={() => handleBoxClick("want2")}
@@ -201,8 +163,9 @@ const PositionBox = (props: PositionBoxProps) => {
           />
           {openPosition === "want2" && (
             <PositionCategory
+              selectedBox={"want2"}
               onClose={closePosition}
-              boxName={selectedBox}
+              value={positionValue.want?.[1]}
               onSelect={handleCategoryButtonClick}
             />
           )}

--- a/src/components/createBoard/PostBoard.tsx
+++ b/src/components/createBoard/PostBoard.tsx
@@ -101,9 +101,9 @@ const PostBoard = (props: PostBoardProps) => {
       setSelectedDropOption(currentPost.gameMode);
 
       setPositionValue({
-        main: currentPost.mainP,
-        sub: currentPost.subP,
-        want: currentPost.wantP,
+        main: currentPost.mainP || "ANY",
+        sub: currentPost.subP || "ANY",
+        want: currentPost.wantP || [],
       });
 
       setSelectedImageIndex(currentPost.profileImage);
@@ -229,7 +229,13 @@ const PostBoard = (props: PostBoardProps) => {
       contents: textareaValue,
       mainP: isARAM ? "ANY" : positionValue?.main,
       subP: isARAM ? "ANY" : positionValue?.sub,
-      wantP: isARAM ? ["ANY", "ANY"] : positionValue?.want,
+      wantP: isARAM
+        ? ["ANY"]
+        : Array.isArray(positionValue?.want)
+        ? positionValue?.want.length > 0
+          ? positionValue?.want
+          : ["ANY"]
+        : ["ANY"],
     };
 
     console.log("params", params);
@@ -323,9 +329,15 @@ const PostBoard = (props: PostBoardProps) => {
             <PositionBox
               status="posting"
               onPositionChange={handlePositionChange}
-              main={positionValue?.main}
-              sub={positionValue?.sub}
-              want={positionValue?.want}
+              main={positionValue?.main || null}
+              sub={positionValue?.sub || null}
+              want={
+                Array.isArray(positionValue?.want) &&
+                positionValue.want.length === 1 &&
+                positionValue.want[0] === "ANY"
+                  ? []
+                  : positionValue?.want || null
+              }
             />
           </PositionSection>
         )}

--- a/src/components/match/Profile.tsx
+++ b/src/components/match/Profile.tsx
@@ -36,7 +36,7 @@ import {
 import { deleteFriend } from "@/api/friend/delete";
 import { blockMember, unblockMember } from "@/api/block/block";
 import { Mike as MikeType } from "@/types/user/mike";
-import { Position as PositionType } from "@/types/position/position";
+import { Position, PositionType } from "@/types/position/position";
 import RankTier from "../common/RankTier";
 import Alert from "../common/Alert";
 
@@ -119,7 +119,7 @@ const Profile: React.FC<Profile> = ({
         mike: isMike,
         mainP: positionValue.main ?? "ANY",
         subP: positionValue.sub ?? "ANY",
-        wantP: positionValue.want ?? ["ANY", "ANY"],
+        wantP: positionValue.want ?? [],
         gameStyleResponseDTOList: gameStyleIds,
       })
     );
@@ -228,7 +228,7 @@ const Profile: React.FC<Profile> = ({
         await putPosition({
           mainP: newPositionValue.main,
           subP: newPositionValue.sub,
-          wantP: newPositionValue.want || ["ANY", "ANY"],
+          wantP: newPositionValue.want || [],
         });
 
         // 포지션 상태 업데이트
@@ -248,11 +248,13 @@ const Profile: React.FC<Profile> = ({
     }
   };
 
-  const handleCategoryButtonClick = (positionName: PositionType) => {
+  const handleCategoryButtonClick = (
+    selectedValues: Position | (Position | null)[]
+  ) => {
     if (selectedBox) {
       const newPositionValue = {
         ...positionValue,
-        [selectedBox]: positionName,
+        [selectedBox]: selectedValues,
       };
       setPositionValue(newPositionValue);
       handlePositionChange(newPositionValue);
@@ -527,7 +529,7 @@ const Profile: React.FC<Profile> = ({
             </StyledBox>
           ) : (
             <UnderRow>
-              <Position>
+              <Positions>
                 {POSITIONS.map((position, index) => (
                   <Posi
                     key={index}
@@ -551,13 +553,21 @@ const Profile: React.FC<Profile> = ({
                     />
                     {isPositionOpen[index] && (
                       <PositionCategory
+                        value={
+                          index === 0
+                            ? positionValue.main ?? "ANY"
+                            : index === 1
+                            ? positionValue.sub ?? "ANY"
+                            : (positionValue.want && positionValue.want[0]) ??
+                              "ANY"
+                        }
                         onClose={() => handlePositionClose(index)}
                         onSelect={handleCategoryButtonClick}
                       />
                     )}
                   </Posi>
                 ))}
-              </Position>
+              </Positions>
               {(profileType === "other" || profileType === "me") &&
                 user.championResponseList && (
                   <Champion
@@ -957,7 +967,7 @@ const MsgConfirm = styled(Msg)`
   margin: 80px 0;
 `;
 
-const Position = styled.div`
+const Positions = styled.div`
   display: flex;
   gap: 24px;
   align-items: center;

--- a/src/components/readBoard/ReadBoard.tsx
+++ b/src/components/readBoard/ReadBoard.tsx
@@ -610,9 +610,13 @@ const ReadBoard = (props: ReadBoardProps) => {
                   <Title>포지션</Title>
                   <PositionBox
                     status="reading"
-                    main={isPost.mainP}
-                    sub={isPost.subP}
-                    want={isPost.wantP}
+                    main={isPost.mainP || null}
+                    sub={isPost.subP || null}
+                    want={
+                      Array.isArray(isPost.wantP)
+                        ? isPost.wantP.filter((v) => v !== null)
+                        : null
+                    }
                   />
                 </PositionSection>
               )}

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -12,6 +12,7 @@ export interface Manner {
   memberId?: number;
   mannerLevel: number;
   mannerRank: number;
+  mannerRatingCount?: number;
   mannerKeywords: { mannerKeywordId: number; count: number }[];
 }
 
@@ -88,14 +89,14 @@ const UserProfile = ({
                   매너 레벨은 겜구 사용자로부터 받은 매너평가, 비매너평가를
                   반영한 지표예요.
                   <br />
-                  최근 <Span>{profile.mannerRatingCount}</Span>명의 사용자가
+                  최근 <Span>{manner.mannerRatingCount}</Span>명의 사용자가
                   {` `}
                   {profile.gameName}
                   {` `}님에게 긍정적 매너 평가를 남겼어요.
                 </Text>
                 <MannerLevelBar
                   recentLevel={manner.mannerLevel}
-                  mannerRank={profile.mannerRank || null}
+                  mannerRank={manner.mannerRank || null}
                 />
               </Box>
             </div>

--- a/src/constants/position.ts
+++ b/src/constants/position.ts
@@ -1,7 +1,6 @@
 import { Position } from "@/types/position/position";
 
 export const POSITION = [
-    { id: 0, key: null, image: null },
     { id: 1, key: "ANY" as Position, image: "all" },
     { id: 2, key: "TOP" as Position, image: "top" },
     { id: 3, key: "JUNGLE" as Position, image: "jungle" },

--- a/src/constants/position.ts
+++ b/src/constants/position.ts
@@ -1,0 +1,11 @@
+import { Position } from "@/types/position/position";
+
+export const POSITION = [
+    { id: 0, key: null, image: null },
+    { id: 1, key: "ANY" as Position, image: "all" },
+    { id: 2, key: "TOP" as Position, image: "top" },
+    { id: 3, key: "JUNGLE" as Position, image: "jungle" },
+    { id: 4, key: "MID" as Position, image: "mid" },
+    { id: 5, key: "ADC" as Position, image: "one_deal" } ,
+    { id: 0, key: "SUP" as Position , image:"supporter" },
+];

--- a/src/data/profile/default.ts
+++ b/src/data/profile/default.ts
@@ -11,9 +11,6 @@ export const DEFAULT_PROFILE = {
   freeTier: "UNRANKED",
   soloRank: 3,
   freeRank: 0,
-  mannerLevel: 4,
-  mannerRank: 15,
-  mannerRatingCount: 4,
   updatedAt: "",
   mainP: "ANY" as Position,
   subP: "ANY" as Position,
@@ -57,57 +54,58 @@ export const DEFAULT_PROFILE = {
 };
 
 export const DEFAULT_MANNER = {
-    memberId: 0,
-    mannerLevel: 4,
-    mannerRank: 15,
-    mannerKeywords: [
-        {
-            mannerKeywordId: 1,
-            count: 0,
-        },
-        {
-            mannerKeywordId: 2,
-            count: 0,
-        },
-        {
-            mannerKeywordId: 3,
-            count: 0,
-        },
-        {
-            mannerKeywordId: 4,
-            count: 0,
-        },
-        {
-            mannerKeywordId: 5,
-            count: 0,
-        },
-        {
-            mannerKeywordId: 6,
-            count: 0,
-        },
-        {
-            mannerKeywordId: 7,
-            count: 0,
-        },
-        {
-            mannerKeywordId: 8,
-            count: 0,
-        },
-        {
-            mannerKeywordId: 9,
-            count: 0,
-        },
-        {
-            mannerKeywordId: 10,
-            count: 0,
-        },
-        {
-            mannerKeywordId: 11,
-            count: 0,
-        },
-        {
-            mannerKeywordId: 12,
-            count: 0,
-        },
-    ],
+  memberId: 0,
+  mannerLevel: 4,
+  mannerRank: 15,
+  mannerRatingCount: 4,
+  mannerKeywords: [
+    {
+      mannerKeywordId: 1,
+      count: 0,
+    },
+    {
+      mannerKeywordId: 2,
+      count: 0,
+    },
+    {
+      mannerKeywordId: 3,
+      count: 0,
+    },
+    {
+      mannerKeywordId: 4,
+      count: 0,
+    },
+    {
+      mannerKeywordId: 5,
+      count: 0,
+    },
+    {
+      mannerKeywordId: 6,
+      count: 0,
+    },
+    {
+      mannerKeywordId: 7,
+      count: 0,
+    },
+    {
+      mannerKeywordId: 8,
+      count: 0,
+    },
+    {
+      mannerKeywordId: 9,
+      count: 0,
+    },
+    {
+      mannerKeywordId: 10,
+      count: 0,
+    },
+    {
+      mannerKeywordId: 11,
+      count: 0,
+    },
+    {
+      mannerKeywordId: 12,
+      count: 0,
+    },
+  ],
 };

--- a/src/interface/board.ts
+++ b/src/interface/board.ts
@@ -25,7 +25,7 @@ export interface BoardListDetail {
   gameMode: GameMode;
   mainP: Position;
   subP: Position;
-  wantP: Position[];
+  wantP: (Position|null)[];
   championResponseList?: ChampionResponseDTOList[];
   winRate: number;
   createdAt: string;

--- a/src/interface/profile.ts
+++ b/src/interface/profile.ts
@@ -24,9 +24,9 @@ export interface User {
   freeTier: string;
   soloRank: number;
   freeRank: number;
-  mannerLevel: number;
-  mannerRank?: null | number;
-  mannerRatingCount?: number;
+  // mannerLevel: number;
+  // mannerRank?: null | number;
+  // mannerRatingCount?: number;
   updatedAt: string;
   mainP: Position;
   subP: Position;

--- a/src/redux/slices/matchInfo.ts
+++ b/src/redux/slices/matchInfo.ts
@@ -6,7 +6,7 @@ export interface MatchInfoState {
   mike: Mike | null;                        // 마이크 사용 여부
   mainP: Position;                             // 주 포지션
   subP: Position;                              // 부 포지션
-  wantP: Position[];                             // 원하는 포지션
+  wantP: (Position|null)[];                             // 원하는 포지션
   gameStyleResponseDTOList: number[];          // 게임 스타일 목록
 }
 

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -14,8 +14,8 @@ interface UserState {
   freeTier: string;
   soloRank: number;
   freeRank: number;
-  mannerRank: number;
-  mannerLevel: number;
+  // mannerRank: number;
+  // mannerLevel: number;
   updatedAt: string;
   mainP: Position;
   subP: Position;
@@ -43,12 +43,12 @@ const initialState: UserState = {
   freeTier: "",
   soloRank: 0,
   freeRank: 0,
-  mannerRank: 0,
-  mannerLevel: 0,
+  // mannerRank: 0,
+  // mannerLevel: 0,
   updatedAt: "",
   mainP: "ANY",
   subP: "ANY",
-  wantP: ["ANY", "ANY"],
+  wantP: [],
   isAgree: false,
   isBlind: false,
   loginType: "",
@@ -91,12 +91,12 @@ export const userSlice = createSlice({
       state.freeTier = '';
       state.soloRank = 0;
       state.freeRank = 0;
-      state.mannerRank = 0;
-      state.mannerLevel = 0;
+      // state.mannerRank = 0;
+      // state.mannerLevel = 0;
       state.updatedAt = '';
       state.mainP = "ANY";
       state.subP = "ANY";
-      state.wantP = ["ANY", "ANY"];
+      state.wantP = [];
       state.isAgree = false;
       state.isBlind = false;
       state.loginType = '';

--- a/src/types/api/user/profile/get.d.ts
+++ b/src/types/api/user/profile/get.d.ts
@@ -12,8 +12,6 @@ interface BaseProfileData {
   freeTier: string;
   soloRank: number;
   freeRank: number;
-  mannerRank: number;
-  mannerLevel: number;
   updatedAt: string;
   mainP: Position;
   subP: Position;
@@ -32,7 +30,6 @@ export interface GetMyProfileData extends BaseProfileData {
 }
 
 export interface GetOtherProfileData extends BaseProfileData {
-  mannerRatingCount: number;
   blocked: boolean;
   friend: boolean;
   friendRequestMemberId: number;

--- a/src/types/api/user/profile/put.d.ts
+++ b/src/types/api/user/profile/put.d.ts
@@ -4,7 +4,7 @@ import { ApiResponse } from "../../api";
 interface PutPositionRequest {
   mainP: Position;
   subP: Position;
-  wantP: Position[];
+  wantP: (Position|null)[];
 }
 
 export interface PutProfileData {

--- a/src/types/position/position.d.ts
+++ b/src/types/position/position.d.ts
@@ -1,3 +1,3 @@
 export type Position = "ANY" | "TOP" | "JUNGLE" | "MID" | "ADC" | "SUP";
 
-export type PositionType = "main" | "sub" | "want1" | "want2";
+export type PositionType = "main" | "sub" | "want";

--- a/src/types/position/position.d.ts
+++ b/src/types/position/position.d.ts
@@ -1,1 +1,3 @@
 export type Position = "ANY" | "TOP" | "JUNGLE" | "MID" | "ADC" | "SUP";
+
+export type PositionType = "main" | "sub" | "want1" | "want2";


### PR DESCRIPTION
## 연관 이슈

close #204

<br/>

## 📁 작업 내용
찾는 포지션 설정 방식 변경

- `PositionBox.tsx` 및 `PositionCategory.tsx` 리팩토링
- wantP 설정 방식 변경에 따른 컴포넌트 수정
- 관련 API 재연결
- 프로필 조회 API 매너관련 정보 삭제
- 매너 평가 관련 오류 수정 (request body 필드명 추가해서 데이터 전송)
<br/>

## 🖥 구현 결과 (선택)

https://github.com/user-attachments/assets/6294f129-8263-40c8-afaa-4486ec13b1aa



<br/>


## 📁 기타 사항
- `main`이나 `sub`는 필수값이 하나 필요하므로 단일 Position 타입으로, `want`는 선택값이고 최대 2개까지 선택이 가능하므로 Position 배열[]로 관리했습니다! 따라서, 선택 로직도 구분지었어요.
- 글 작성이나 수정 시에는 `wantP`값이 필수라서 선택값이 없을 경우 무조건 ["ANY"]로 보내게 했고, 게시판 글 목록이나 게시글 상세 조회에서는 ["ANY"]로 받은 값 그대로 보여주고, 글 수정할 때는 아예 빈 값으로 넘겨서 ANY로 선택되는 것이 아닌 설정값이 없도록 화면에 보이게 했습니다! 매칭 쪽도 이렇게 수정 필요할 것 같아요.
<br/>
