### PR TITLE
[Feat] 챔피언 상세 정보 추가

### DIFF
--- a/src/components/board/Table.tsx
+++ b/src/components/board/Table.tsx
@@ -243,7 +243,7 @@ const Table = (props: TableProps) => {
                     </P>
                   </Seventh>
                   <Eighth className="table_width">
-                    <P>{data.contents}</P>
+                    <Content>{data.contents}</Content>
                   </Eighth>
                   <Ninth className="table_width">
                     <P className="gray">{setDateFormatter(data.createdAt)}</P>
@@ -355,6 +355,7 @@ const ProfileImgWrapper = styled.div<{ $bgColor: string }>`
   height: 50px;
   background: ${(props) => props.$bgColor};
   border-radius: 50%;
+  aspect-ratio: 1;
 `;
 
 const ProfileImg = styled.object`
@@ -426,6 +427,23 @@ const P = styled.p`
     color: ${theme.colors.gray500};
     ${(props) => props.theme.fonts.medium16};
   }
+`;
+
+const Content = styled.div`
+  display: -webkit-box;
+  width: 156px;
+  max-height: 52px;
+  padding: 8px;
+  text-align: center;
+  border-radius: 8px;
+  border: 1px solid ${theme.colors.gray400};
+  background: ${theme.colors.gray100};
+  color: ${theme.colors.gray700};
+  ${(props) => props.theme.fonts.regular13};
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const CopyButton = styled.button`

--- a/src/components/board/Table.tsx
+++ b/src/components/board/Table.tsx
@@ -234,9 +234,7 @@ const Table = (props: TableProps) => {
                   <Sixth className="table_width">
                     <Champion
                       font="semiBold14"
-                      list={data?.championResponseList?.map(
-                        (champion) => champion.championId
-                      )}
+                      list={data?.championResponseList || []}
                     />
                   </Sixth>
                   <Seventh className="table_width">

--- a/src/components/match/Profile.tsx
+++ b/src/components/match/Profile.tsx
@@ -573,9 +573,7 @@ const Profile: React.FC<Profile> = ({
                   <Champion
                     title={true}
                     font="regular14"
-                    list={user.championResponseList.map(
-                      (champion) => champion.championId
-                    )}
+                    list={user.championResponseList}
                   />
                 )}
               <Mike>

--- a/src/components/readBoard/Champion.tsx
+++ b/src/components/readBoard/Champion.tsx
@@ -1,15 +1,20 @@
 import styled from "styled-components";
 import Image from "next/image";
 import { theme } from "@/styles/theme";
+import { ChampionResponseDTOList } from "@/interface/board";
+import { useState } from "react";
+import { fadeIn, fadeOut } from "@/styles/animation";
 
 interface ChampionProps {
   title?: boolean;
-  list?: number[];
+  list?: ChampionResponseDTOList[];
   font?: string;
 }
 
 const Champion = (props: ChampionProps) => {
   const { list, font = "semiBold18", title = false } = props;
+
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
   // 챔피언 이미지를 로드 실패 시 기본 이미지로
   const handleImageError = (e: any) => {
@@ -22,21 +27,45 @@ const Champion = (props: ChampionProps) => {
       {list?.length !== 0 ? (
         <Champions>
           {list?.map((champion, key) => (
-            <ChampionWrapper key={key}>
+            <ChampionWrapper
+              key={key}
+              onMouseEnter={() => setHoveredIndex(key)}
+              onMouseLeave={() => setHoveredIndex(null)}
+            >
               <ImageWrapper>
                 <Image
-                  src={`/assets/images/champion/${champion}.png`}
+                  src={`/assets/images/champion/${champion.championId}.png`}
                   width={48}
                   height={48}
-                  alt={`champion-${champion}`}
+                  alt={`champion-${champion.championId}`}
                   style={{
                     transform: "scale(1.2)", // 120% 확대
                     objectFit: "cover",
                   }}
                   onError={handleImageError}
                 />
-                <Percentage>52%</Percentage>
+                <Percentage>{champion.winRate}%</Percentage>
               </ImageWrapper>
+              {hoveredIndex === key && (
+                <Tooltip>
+                  <ChampionName>
+                    <strong>{champion.championName}</strong>
+                  </ChampionName>
+                  <ChampionTable>
+                    <Head>승률</Head>
+                    <Rate>{champion.winRate}%</Rate>
+                    <More>
+                      {champion.wins}승 {champion.games - champion.wins}패
+                    </More>
+                    <Head>KDA</Head>
+                    <Rate>1.98</Rate>
+                    <More>0 / 0 / 0</More>
+                    <Head>CS</Head>
+                    <Rate>{champion.csPerMinute.toFixed(1)}</Rate>
+                    <More>190.6</More>
+                  </ChampionTable>
+                </Tooltip>
+              )}
             </ChampionWrapper>
           ))}
         </Champions>
@@ -94,6 +123,71 @@ const Percentage = styled.div`
   bottom: 0;
   left: 50%;
   transform: translateX(-50%);
+`;
+
+const Tooltip = styled.div`
+  position: absolute;
+  bottom: -170px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 223px;
+  height: 154px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.7);
+  color: ${theme.colors.white};
+  border-radius: 14px;
+  ${theme.fonts.regular14};
+  box-shadow: 0px 3px 6px 0px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(5.3px);
+  z-index: 10;
+  text-align: left;
+  animation: ${fadeIn} 0.3s ease-in-out;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: -12px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 6px;
+    border-style: solid;
+    border-color: transparent transparent rgba(0, 0, 0, 0.7) transparent;
+  }
+
+  ${ChampionWrapper}:not(:hover) & {
+    animation: ${fadeOut} 0.3s ease-in-out;
+  }
+`;
+
+const ChampionName = styled.div`
+  color: ${theme.colors.gray100};
+  ${theme.fonts.regular18};
+`;
+
+const ChampionTable = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 2fr;
+  grid-template-rows: repeat(3, 1fr);
+  row-gap: 6px;
+  column-gap: 20px;
+`;
+
+const Head = styled.div`
+  color: ${theme.colors.gray500};
+  ${theme.fonts.bold14};
+`;
+
+const Rate = styled.div`
+  color: ${theme.colors.gray100};
+  ${theme.fonts.bold14};
+`;
+
+const More = styled.div`
+  color: ${theme.colors.gray100};
+  ${theme.fonts.regular14};
 `;
 
 const NoData = styled.div`

--- a/src/components/readBoard/ReadBoard.tsx
+++ b/src/components/readBoard/ReadBoard.tsx
@@ -599,9 +599,7 @@ const ReadBoard = (props: ReadBoardProps) => {
                 <Champion
                   title={true}
                   font="semiBold14"
-                  list={isPost?.championResponseList?.map(
-                    (champion) => champion.championId
-                  )}
+                  list={isPost?.championResponseDTOList}
                 />
                 <QueueType value={isPost.gameMode} />
               </ChampionNQueueSection>

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -188,9 +188,7 @@ const UserProfile = ({
                 <Champion
                   title={true}
                   font="regular14"
-                  list={profile.championResponseList.map(
-                    (champion) => champion.championId
-                  )}
+                  list={profile.championResponseList}
                 />
               </RecentBox>
             </div>

--- a/src/interface/board.ts
+++ b/src/interface/board.ts
@@ -6,6 +6,10 @@ import { Mike } from "@/types/user/mike";
 export interface ChampionResponseDTOList {
   championId: number;
   championName: string;
+  csPerMinute: number;
+  games: number;
+  winRate: number;
+  wins: number;
 }
 
 export interface gameStyleResponseDTOList {

--- a/src/interface/profile.ts
+++ b/src/interface/profile.ts
@@ -6,6 +6,10 @@ export type profileType = "normal" | "wind" | "other" | "me";
 export interface Champion {
   championId: number;
   championName: string;
+  csPerMinute: number;
+  games: number;
+  winRate: number;
+  wins: number;
 }
 
 export interface GameStyle {
@@ -56,6 +60,8 @@ export interface GameStyleList {
 export interface ChampionList {
   championId: number;
   championName: string;
+  winRate: number;
+  games: number;
 }
 
 export interface UserInfo {

--- a/src/styles/animation.ts
+++ b/src/styles/animation.ts
@@ -8,3 +8,20 @@ export const rotate = keyframes`
     transform: rotate(360deg);
   }
 `;
+export const fadeIn = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+`;
+
+export const fadeOut = keyframes`
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+`;


### PR DESCRIPTION
## 연관 이슈

close #223

<br/>

## 📁 작업 내용
- 챔피언 상세정보 추가
- 게시판 한마디 스타일 변경 및 게시판 프로필 찌그러짐 수정

<br/>

## 🖥 구현 결과 (선택)

https://github.com/user-attachments/assets/c0b5e7dd-c949-4a69-9663-ddb90913dcce



<br/>


## 📁 기타 사항
- 현재 챔피언 관련 서버에서 넘어오는 필드명이 일치하지 않아서 게시판 목록이나 프로필 쪽에는 안 나오고, 게시글 상세보기에서만 적용됩니다! ChampionResponseDTO 로 넘어오게 + 몇 개 빠진 정보들까지 담겨오게 수정 부탁드리면 될 것 같아요. 필드명 바꿔봤을 때 들어오게 하는 거까지 테스트해봤습니다! (KDA랑 CS 쪽 상세 정보는 아직 반영이 안 된 것 같아 더미로 넣었습니다!)
- fadeIn, fadeOut 애니메이션 `/styles/animation.ts`에 정의해두었어요. 필요하시면 여기서 import 해서 사용하시면 좋을 것 같아요! 이렇게 자주 사용할만한 애니메이션은 해당 파일에 넣어놓고 사용하겠습니다~!

<br/>
