### PR TITLE
[Feat] 라이엇 회원가입 API 연동

### DIFF
--- a/src/app/join/terms/page.tsx
+++ b/src/app/join/terms/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { postRiotJoin } from "@/api/riot/join";
 import Button from "@/components/common/Button";
 import Checkbox from "@/components/common/Checkbox";
 import TermModal from "@/components/common/TermModal";
@@ -9,7 +10,8 @@ import {
   PRIVATE_TERMS,
 } from "@/constants/terms";
 import { createTerms } from "@/data/terms";
-import { updateTerms } from "@/redux/slices/signInSlice";
+import { notify } from "@/hooks/notify";
+import { clearSignIn, updateTerms } from "@/redux/slices/signInSlice";
 import { RootState } from "@/redux/store";
 import { theme } from "@/styles/theme";
 import { useRouter } from "next/navigation";
@@ -20,8 +22,12 @@ import styled from "styled-components";
 const Terms = () => {
   const router = useRouter();
   const dispatch = useDispatch();
-  const [terms, setTerms] = useState<boolean[]>([false, false, false]);
+  const url = new URL(window.location.href);
+  const puuid = url.searchParams.get("puuid");
+  // const state = url.searchParams.get("state");
 
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [terms, setTerms] = useState<boolean[]>([false, false, false]);
   const termsRedux = useSelector((state: RootState) => state.signIn.terms);
 
   const [modalData, setModalData] = useState<{
@@ -42,9 +48,37 @@ const Terms = () => {
     setTerms(newTerms);
   };
 
-  const handleNext = async () => {
-    dispatch(updateTerms(terms));
-    router.push("/join/email");
+  // const handleNext = async () => {
+  //   dispatch(updateTerms(terms));
+  //   router.push("/join/email");
+  // };
+
+  const handleSendJoin = async () => {
+    if (puuid) {
+      setIsLoading(true);
+      try {
+        await postRiotJoin({
+          puuid,
+          isAgree: terms[2],
+        });
+        dispatch(clearSignIn());
+        router.push("/riot");
+      } catch (err) {
+        notify({
+          text: "회원가입에 실패했습니다. 다시 시도해주세요.",
+          icon: "🚫",
+          type: "error",
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    } else {
+      notify({
+        text: "Riot 로그인으로 회원가입을 진행해주세요.",
+        icon: "🚫",
+        type: "error",
+      });
+    }
   };
 
   const openModal = (type: string, index: number) => {
@@ -117,8 +151,8 @@ const Terms = () => {
       </CheckList>
       <Button
         buttonType="primary"
-        text="다음"
-        onClick={handleNext}
+        text={isLoading ? "가입 중..." : "회원가입 완료"}
+        onClick={handleSendJoin}
         disabled={!allRequiredChecked}
       />
     </Div>

--- a/src/app/join/terms/page.tsx
+++ b/src/app/join/terms/page.tsx
@@ -22,7 +22,6 @@ import styled from "styled-components";
 const Terms = () => {
   const router = useRouter();
   const dispatch = useDispatch();
-  const url = new URL(window.location.href);
   const [puuid, setPuuid] = useState<string | null>(null);
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -37,11 +36,9 @@ const Terms = () => {
   } | null>(null);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      const url = new URL(window.location.href);
-      const queryPuuid = url.searchParams.get("puuid");
-      setPuuid(queryPuuid);
-    }
+    const url = new URL(window.location.href);
+    const queryPuuid = url.searchParams.get("puuid");
+    setPuuid(queryPuuid);
   }, []);
 
   /* redux 업데이트 */

--- a/src/app/join/terms/page.tsx
+++ b/src/app/join/terms/page.tsx
@@ -23,8 +23,7 @@ const Terms = () => {
   const router = useRouter();
   const dispatch = useDispatch();
   const url = new URL(window.location.href);
-  const puuid = url.searchParams.get("puuid");
-  // const state = url.searchParams.get("state");
+  const [puuid, setPuuid] = useState<string | null>(null);
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [terms, setTerms] = useState<boolean[]>([false, false, false]);
@@ -36,6 +35,14 @@ const Terms = () => {
     isRequired: boolean;
     index: number;
   } | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const url = new URL(window.location.href);
+      const queryPuuid = url.searchParams.get("puuid");
+      setPuuid(queryPuuid);
+    }
+  }, []);
 
   /* redux 업데이트 */
   useEffect(() => {

--- a/src/app/oauth/page.tsx
+++ b/src/app/oauth/page.tsx
@@ -1,43 +1,10 @@
 "use client";
 
-import axios from "axios";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { useEffect } from "react";
-import { decode as base64urlDecode } from "js-base64";
+import styled from "styled-components";
 
 const Oauth = () => {
-  // 기존 테스트용 코드
-  // useEffect(() => {
-  //   const getToken = async () => {
-  //     const CODE = new URL(window.location.href).searchParams.get("code");
-  //     try {
-  //       const formData = new URLSearchParams();
-  //       formData.append("grant_type", "authorization_code");
-  //       formData.append("code", CODE || "");
-  //       formData.append("redirect_uri", "https://www.gamegoo.co.kr/oauth");
-  //       // const response = await axios.post(
-  //       //   `https://auth.riotgames.com/token`,
-  //       //   formData,
-  //       //   {
-  //       //     auth: {
-  //       //       username: "43277efb-2a7d-488f-bb73-6c49c40d7099",
-  //       //       password: "qMKnKBIxNY7QEAWM1tqPw12MM-55fNy2LGM4xeeQMiD",
-  //       //     },
-  //       //     headers: {
-  //       //       "Content-Type": "application/x-www-form-urlencoded",
-  //       //     },
-  //       //   }
-  //       // );
-  //       const re
-  //       console.log(response);
-  //       console.log(response.data);
-  //     } catch (error) {
-  //       console.error(error);
-  //       return;
-  //     }
-  //   };
-  //   getToken();
-  // });
-
   useEffect(() => {
     const handleCallback = async () => {
       const url = new URL(window.location.href);
@@ -48,31 +15,23 @@ const Oauth = () => {
         console.error("Missing code or state");
         return;
       }
-
-      // try {
-      //   const decodedState = JSON.parse(base64urlDecode(stateParam));
-      //   const csrfInSession = sessionStorage.getItem("csrfToken");
-
-      //   if (decodedState.csrfToken !== csrfInSession) {
-      //     console.error("CSRF token mismatch");
-      //     return;
-      //   }
-
-      //   // 백엔드로 code와 state 전달 (GET)
-      //   await axios.get(`/api/v2/riot/oauth/callback`, {
-      //     params: {
-      //       code,
-      //       state: stateParam,
-      //     },
-      //   });
-      // } catch (err) {
-      //   console.error("OAuth 처리 실패:", err);
-      // }
     };
 
     handleCallback();
   }, []);
-  return <div>테스트</div>;
+  return (
+    <LoadingContainer>
+      <LoadingSpinner />
+    </LoadingContainer>
+  );
 };
 
 export default Oauth;
+
+const LoadingContainer = styled.div`
+  height: 500px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px 0;
+`;

--- a/src/app/riot/callback/page.tsx
+++ b/src/app/riot/callback/page.tsx
@@ -3,9 +3,18 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { setToken } from "@/utils/storage";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+import styled from "styled-components";
+import { useDispatch } from "react-redux";
+import {
+  setUserId,
+  setUserName,
+  setUserProfileImg,
+} from "@/redux/slices/userSlice";
 
 const RsoCallback = () => {
   const router = useRouter();
+  const dispatch = useDispatch();
 
   useEffect(() => {
     const url = new URL(window.location.href);
@@ -16,25 +25,38 @@ const RsoCallback = () => {
 
     if (accessToken && refreshToken) {
       // 로그인 완료 처리
-      console.log("라이엇 로그인 성공");
-      setToken(accessToken, refreshToken, false); // 자동 로그인 유무 확인
+      setToken(accessToken, refreshToken, true);
       // 서버 응답값 추가 필요
       //   dispatch(setUserName(response.data.name));
       //   dispatch(setUserProfileImg(response.data.profileImage));
       //   dispatch(setUserId(response.data.id));
-      //   setName(response.data.name, autoLogin);
-      //   setProfileImg(response.data.profileImage, autoLogin);
-      //   setId(response.data.id, autoLogin);
+
+      // 테스트용 redux 설정
+      dispatch(setUserName("라이엇"));
+      dispatch(setUserProfileImg(1));
+      dispatch(setUserId(8));
       router.push("/");
     } else if (puuid) {
       // 회원가입 페이지로 이동
-      router.push(`/signup?puuid=${puuid}&state=${state}`);
+      router.push(`/join/terms?puuid=${puuid}&state=${state}`);
     } else {
       console.error("유효하지 않은 응답입니다.");
     }
   }, []);
 
-  return <div>사용자 처리 중...</div>;
+  return (
+    <LoadingContainer>
+      <LoadingSpinner />
+    </LoadingContainer>
+  );
 };
 
 export default RsoCallback;
+
+const LoadingContainer = styled.div`
+  height: 500px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px 0;
+`;


### PR DESCRIPTION
## 연관 이슈

#222

<br/>

## 📁 작업 내용
라이엇 회원가입 API 연동
- `/riot/callback`, `/oauth` 경로 내 로딩 컴포넌트 설정
- `puuid`를 전달해 라이엇 회원가입 API 연동
<br/>

## 📁 기타 사항
- RSO 로그인 시 accessToken, refreshToken 외 id, name, profileImage 전달받아 redux 저장 필요.
- 소환사명이 없는 경우 404 코드 대신 error 파라미터로 오류를 받아 처리 필요.

p.s. 이거는 기타사항에 남긴 것처럼 응답 형식이 바뀌어야 해서, 반영되면 수정해서 제가 합치겠습니다!
<br/>
