### PR TITLE
[Design] 내 프로필 매너레벨 확인 추가

### DIFF
--- a/src/components/common/MannerLevelBox.tsx
+++ b/src/components/common/MannerLevelBox.tsx
@@ -5,17 +5,19 @@ import { useEffect, useState } from "react";
 import { MannerKeywords } from "@/interface/manner";
 import { getMemberMannerKeyword } from "@/api/manner/manner";
 import Image from "next/image";
+import { css } from "styled-components";
 
 interface MannerLevelBoxProps {
   memberId: number;
   level: number;
   top: string;
   right: string;
+  tail?: boolean;
   onClose?: () => void;
 }
 
 const MannerLevelBox = (props: MannerLevelBoxProps) => {
-  const { memberId, level, top, right, onClose } = props;
+  const { memberId, level, top, right, tail = false, onClose } = props;
 
   const [positiveKeywords, setPositiveKeywords] = useState<MannerKeywords[]>(
     []
@@ -55,7 +57,7 @@ const MannerLevelBox = (props: MannerLevelBoxProps) => {
   };
 
   return (
-    <Wrapper $top={top} $right={right}>
+    <Wrapper $top={top} $right={right} $tail={tail}>
       <TitleWrap>
         <Title>매너 레벨 {level}</Title>
         <CloseImage
@@ -107,7 +109,7 @@ const MannerLevelBox = (props: MannerLevelBoxProps) => {
 
 export default MannerLevelBox;
 
-const Wrapper = styled.div<{ $top: string; $right: string }>`
+const Wrapper = styled.div<{ $top: string; $right: string; $tail: boolean }>`
   position: absolute;
   top: ${({ $top }) => $top};
   right: ${({ $right }) => $right};
@@ -119,6 +121,22 @@ const Wrapper = styled.div<{ $top: string; $right: string }>`
   width: fit-content;
   z-index: 100;
   white-space: nowrap;
+
+  ${({ $tail }) =>
+    $tail &&
+    css`
+      &:after {
+        content: "";
+        position: absolute;
+        top: -15px;
+        left: 50%;
+        transform: translateX(-50%); /* 정중앙으로 이동 */
+        border-top: 0 solid transparent;
+        border-left: 9px solid transparent;
+        border-right: 9px solid transparent;
+        border-bottom: 15px solid rgba(0, 0, 0, 0.64);
+      }
+    `}
 
   @media (max-width: 700px) {
     padding: 20px;

--- a/src/components/common/PositionCategory.tsx
+++ b/src/components/common/PositionCategory.tsx
@@ -10,6 +10,7 @@ import Jungle from "../../../public/assets/images/position/position_jungle_uncli
 import Mid from "../../../public/assets/images/position/position_mid_unclicked.svg";
 import OneDeal from "../../../public/assets/images/position/position_one_deal_unclicked.svg";
 import Supporter from "../../../public/assets/images/position/position_supporter_unclicked.svg";
+import useMediaQueries from "@/hooks/useMediaQueries";
 
 interface PositionComponentProps {
   selectedBox?: PositionType | null;
@@ -20,6 +21,7 @@ interface PositionComponentProps {
 
 const PositionCategory = (props: PositionComponentProps) => {
   const { selectedBox, value = [], onSelect, onClose } = props;
+  const isMobile = useMediaQueries({ breakpoint: 700 });
   const boxRef = React.useRef<HTMLDivElement>(null);
 
   const handlePositionCategory = (positionName: Position | null) => {
@@ -100,7 +102,14 @@ const PositionCategory = (props: PositionComponentProps) => {
   return (
     <Wrapper>
       <Header>
-        <Title>주 포지션 선택</Title>
+        <Title>
+          {selectedBox === "main"
+            ? "주"
+            : selectedBox === "sub"
+            ? "부"
+            : "내가 찾는"}{" "}
+          포지션 선택
+        </Title>
         <CloseButton onClick={() => handleClose()}>
           <Image
             src={"/assets/icons/close_white.svg"}
@@ -152,10 +161,14 @@ const Wrapper = styled.div`
   /* Background Blur */
   box-shadow: 0 4px 8.9px 0 rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(7.5px);
+
+  @media (max-width: 700px) {
+    width: 224px;
+  }
 `;
 
 const Header = styled.div`
-  margin-bottom: 45px;
+  margin-bottom: 12px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -178,19 +191,27 @@ const Box = styled.div<{ $isWant: boolean }>`
     border-top: 0 solid transparent;
     border-left: 9px solid transparent;
     border-right: 9px solid transparent;
-    border-bottom: 18px solid ${theme.colors.gray900};
+    border-bottom: 18px solid rgba(0, 0, 0, 0.64);
     content: "";
     position: absolute;
-    top: -13px;
+    top: -18px;
     left: 27px;
+  }
+
+  @media (max-width: 700px) {
+    width: 184px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    row-gap: 20px;
+    column-gap: 0px;
   }
 `;
 
 const StyledButton = styled.button<{ $posKey: Position }>`
   width: 48px;
+  height: 48px;
   /* TODO */
-  /* background: ${(props) =>
-    props.$posKey ? theme.colors.violet600 : ""};   */
+  /* background: ${(props) => (props.$posKey ? theme.colors.violet600 : "")}; */
   border: none;
   padding: 0;
   cursor: pointer;

--- a/src/components/match/Profile.tsx
+++ b/src/components/match/Profile.tsx
@@ -567,13 +567,14 @@ const Profile: React.FC<Profile> = ({
                             : (positionValue.want && positionValue.want[0]) ??
                               "ANY"
                         )}
-                        width={!isMobile ? 55 : 41}
-                        height={!isMobile ? 40 : 32}
+                        width={!isMobile ? 55 : 22}
+                        height={!isMobile ? 40 : 22}
                         alt="포지션"
                         onClick={() => handlePosition(index)}
                       />
                       {isPositionOpen[index] && (
                         <PositionCategory
+                          selectedBox={index === 0 ? "main" : "sub"}
                           value={
                             index === 0
                               ? positionValue.main ?? "ANY"
@@ -598,13 +599,14 @@ const Profile: React.FC<Profile> = ({
                       src={setPositionImg(
                         (positionValue.want && positionValue.want[0]) ?? "ANY"
                       )}
-                      width={!isMobile ? 55 : 41}
-                      height={!isMobile ? 40 : 32}
+                      width={!isMobile ? 55 : 22}
+                      height={!isMobile ? 40 : 22}
                       alt="포지션"
                       onClick={() => handlePosition(2)}
                     />
                     {isPositionOpen[2] && (
                       <PositionCategory
+                        selectedBox="want"
                         value={
                           (positionValue.want && positionValue.want[0]) ?? "ANY"
                         }
@@ -1089,27 +1091,33 @@ const Positions = styled.div`
   display: flex;
   align-items: center;
   width: 412px;
-  gap: 8px;
+  gap: 12px;
   @media (max-width: 700px) {
     width: 100%;
   }
 `;
 
 const PosiWrap = styled.div`
+  height: 104px;
   display: flex;
   justify-content: center;
   gap: 12px;
-  background-color: white;
+  background-color: ${theme.colors.white};
   width: 100%;
   border-radius: 6px;
-  padding: 12px 20px;
+  padding: 16px 32px 12px 32px;
+
+  @media (max-width: 700px) {
+    height: 69px;
+    padding: 12px 20px 8px 20px;
+  }
 `;
 
 const Posi = styled.div<{ $isWantP: boolean }>`
   display: flex;
   flex-direction: column;
-  gap: 15px;
-  align-items: flex-start;
+  gap: 8px;
+  align-items: center;
   font-size: ${theme.fonts.medium16};
   color: ${theme.colors.gray800};
   position: relative;
@@ -1117,12 +1125,6 @@ const Posi = styled.div<{ $isWantP: boolean }>`
   &.other {
     font-size: ${theme.fonts.medium16};
   }
-
-  ${({ $isWantP }) =>
-    $isWantP &&
-    css`
-      /* margin-left: 36px; */
-    `}
 
   @media (max-width: 700px) {
     font-size: ${theme.fonts.medium11};

--- a/src/components/match/SquareProfile.tsx
+++ b/src/components/match/SquareProfile.tsx
@@ -113,25 +113,20 @@ const SquareProfile: React.FC<SquareProfileProps> = ({
                   width={!isMobile ? 100 : 67}
                   height={!isMobile ? 100 : 67}
                 />
-                {opponent ? (
-                  <>
-                    <LevelTag onClick={handleMannerLevel}>
-                      LV. {user.mannerLevel}
-                    </LevelTag>
-                    {mannerPopup && (
-                      <MannerLevelBox
-                        memberId={0}
-                        level={5}
-                        top="20px"
-                        right="-17%"
-                        onClose={() => setMannerPopup(!mannerPopup)}
-                      />
-                    )}
-                    <Bubble>클릭해서 매너키워드 보기</Bubble>
-                  </>
-                ) : (
-                  <LevelTag>LV. {user.mannerLevel}</LevelTag>
+                <LevelTag onClick={handleMannerLevel}>
+                  LV. {user.mannerLevel}
+                </LevelTag>
+                {mannerPopup && (
+                  <MannerLevelBox
+                    memberId={user.memberId}
+                    level={user.mannerLevel}
+                    top="172px"
+                    right="-94%"
+                    tail={true}
+                    onClose={() => setMannerPopup(!mannerPopup)}
+                  />
                 )}
+                <Bubble>클릭해서 매너키워드 보기</Bubble>
               </ProfileImgWrapper>
             </ImageContainer>
             <Mic status={user.mike} />
@@ -276,14 +271,17 @@ const LevelTag = styled.span`
   bottom: -12.5px;
   left: 50%;
   transform: translate(-50%);
+  height: 25px;
   border-radius: 57px;
   padding: 6px 10px;
-  background: ${theme.colors.gray900};
+  background: rgba(0, 0, 0, 0.64);
+
   color: ${theme.colors.violet300};
   ${theme.fonts.bold13}
   backdrop-filter: blur(7.5px);
 
   @media (max-width: 700px) {
+    background: ${theme.colors.gray900};
     ${theme.fonts.bold11}
     padding: 1px 8px;
     bottom: -4px;
@@ -397,14 +395,15 @@ const RowBox = styled(Row)`
 
 const Position = styled.div<{ $opponent: boolean }>`
   width: 100%;
-  height: 116px;
+  height: 104px;
+  padding: 16px 32px 12px 32px;
   border-radius: 8px;
   background: ${theme.colors.gray100};
   display: flex;
   justify-content: center;
   align-items: center;
   gap: 33px;
-  ${theme.fonts.medium11};
+  ${theme.fonts.medium16};
   color: ${theme.colors.gray800};
   @media (max-width: 700px) {
     border-radius: 6px;

--- a/src/components/readBoard/Champion.tsx
+++ b/src/components/readBoard/Champion.tsx
@@ -61,7 +61,11 @@ const Champion = (props: ChampionProps) => {
                     <Rate>1.98</Rate>
                     <More>0 / 0 / 0</More>
                     <Head>CS</Head>
-                    <Rate>{champion.csPerMinute.toFixed(1)}</Rate>
+                    <Rate>
+                      {champion.csPerMinute !== undefined
+                        ? champion.csPerMinute.toFixed(1)
+                        : "-"}
+                    </Rate>
                     <More>190.6</More>
                   </ChampionTable>
                 </Tooltip>


### PR DESCRIPTION
## 연관 이슈

#232

<br/>

## 📁 작업 내용
- 매칭 프로필 선택>포지션 선택 부분 수정 ("주", "부", "내가 찾는" 헤더, 반응형)
- 내 프로필 매너레벨 확인 추가
<br/>

## 🖥 구현 결과 (선택)
https://github.com/user-attachments/assets/f9450c5a-ab8e-4178-8318-cf5dc4ddaec6

![image](https://github.com/user-attachments/assets/4d55165e-ee84-4ca2-a3d7-ecef0690ea3b)

<br/>


## 📁 기타 사항
- 계속 PC 피그마 뷰만 보고 작업해서 몰랐는데 반응형이 추가되면서 은근히 바뀐 부분들이 있더라구요.!! 프로필 반응형 할 때 전체적으로 한번 검토해봐야할 것 같아요.

<br/>
