### PR TITLE
[Fix] Champion 관련 타입 반영 및 게시판 포지션 필터링 오류 수정

### DIFF
--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -166,7 +166,7 @@ const BoardPage = () => {
         boardFilters.tier && boardFilters.tier !== null
           ? boardFilters.tier
           : selectedTier,
-      mainP: boardFilters.mainP || isPosition,
+      mainP: isPosition,
       mike:
         boardFilters.mike && boardFilters.mike !== null
           ? boardFilters.mike

--- a/src/components/board/Table.tsx
+++ b/src/components/board/Table.tsx
@@ -234,7 +234,7 @@ const Table = (props: TableProps) => {
                   <Sixth className="table_width">
                     <Champion
                       font="semiBold14"
-                      list={data?.championResponseList || []}
+                      list={data?.championStatsResponseList || []}
                     />
                   </Sixth>
                   <Seventh className="table_width">

--- a/src/components/readBoard/Champion.tsx
+++ b/src/components/readBoard/Champion.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { theme } from "@/styles/theme";
 import { useState } from "react";
 import { fadeIn, fadeOut } from "@/styles/animation";
-import { ChampionResponseDTO } from "@/types/api/board/board";
+import { ChampionResponseDTO } from "@/types/api/champion/champion";
 
 interface ChampionProps {
   title?: boolean;
@@ -44,7 +44,7 @@ const Champion = (props: ChampionProps) => {
                   }}
                   onError={handleImageError}
                 />
-                <Percentage>{champion.winRate}%</Percentage>
+                <Percentage>{Math.round(champion.winRate)}%</Percentage>
               </ImageWrapper>
               {hoveredIndex === key && (
                 <Tooltip>
@@ -53,9 +53,11 @@ const Champion = (props: ChampionProps) => {
                   </ChampionName>
                   <ChampionTable>
                     <Head>승률</Head>
-                    <Rate>{champion.winRate}%</Rate>
+                    <Rate>{Math.round(champion.winRate)}%</Rate>
+                    {/* TODO: 추후 wins 값 들어오면 수정 */}
                     <More>
-                      {champion.wins}승 {champion.games - champion.wins}패
+                      {champion.wins || "0"}승{" "}
+                      {champion.wins ? champion.games - champion.wins : "0"}패
                     </More>
                     <Head>KDA</Head>
                     <Rate>1.98</Rate>

--- a/src/components/readBoard/Champion.tsx
+++ b/src/components/readBoard/Champion.tsx
@@ -155,7 +155,7 @@ const Tooltip = styled.div`
   &::before {
     content: "";
     position: absolute;
-    top: -12px;
+    top: -10.5px;
     left: 50%;
     transform: translateX(-50%);
     border-width: 6px;

--- a/src/components/readBoard/ReadBoard.tsx
+++ b/src/components/readBoard/ReadBoard.tsx
@@ -599,7 +599,7 @@ const ReadBoard = (props: ReadBoardProps) => {
                 <Champion
                   title={true}
                   font="semiBold14"
-                  list={isPost?.championResponseDTOList}
+                  list={isPost?.championStatsResponseList}
                 />
                 <QueueType value={isPost.gameMode} />
               </ChampionNQueueSection>

--- a/src/components/user/BlindProfile.tsx
+++ b/src/components/user/BlindProfile.tsx
@@ -29,6 +29,7 @@ const BlindProfile = () => {
             title="탈퇴한 사용자 님의 프로필"
             size="bold"
             marginBottom="20px"
+            isMatchProgressOrComplete={true}
           />
         </Row>
         <Main>

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -69,6 +69,7 @@ const UserProfile = ({
             size="bold"
             blocked={profile.blocked}
             marginBottom="20px"
+            isMatchProgressOrComplete={true}
           />
         </Row>
         <Main>

--- a/src/interface/board.ts
+++ b/src/interface/board.ts
@@ -1,4 +1,5 @@
-import { ChampionResponseDTO, MannerKeywordDTO } from "@/types/api/board/board";
+import { MannerKeywordDTO } from "@/types/api/board/board";
+import { ChampionResponseDTO } from "@/types/api/champion/champion";
 import { GameMode } from "@/types/game/gameMode";
 import { Position } from "@/types/position/position";
 import { Mike } from "@/types/user/mike";
@@ -30,7 +31,7 @@ export interface BoardListDetail {
   mainP: Position;
   subP: Position;
   wantP: (Position | null)[];
-  championResponseList?: ChampionResponseDTO[];
+  championStatsResponseList?: ChampionResponseDTO[];
   winRate: number;
   createdAt: string;
   contents: string;
@@ -79,8 +80,7 @@ export interface MemberPost {
   soloTier?: string;
   freeTier?: string;
   mike: Mike;
-  championResponseList?: ChampionResponseDTO[];
-  championResponseDTOList?: ChampionResponseDTO[];
+  championStatsResponseList?: ChampionResponseDTO[];
   gameMode: GameMode;
   mainP?: Position;
   subP?: Position;

--- a/src/interface/profile.ts
+++ b/src/interface/profile.ts
@@ -1,17 +1,8 @@
-import { ChampionResponseDTO } from "@/types/api/board/board";
+import { ChampionResponseDTO } from "@/types/api/champion/champion";
 import { Position } from "@/types/position/position";
 import { Mike } from "@/types/user/mike";
 
 export type profileType = "normal" | "wind" | "other" | "me";
-
-// export interface Champion {
-//   championId: number;
-//   championName: string;
-//   // csPerMinute: number;
-//   games: number;
-//   winRate: number;
-//   // wins: number;
-// }
 
 export interface GameStyle {
   gameStyleId: number;
@@ -29,9 +20,6 @@ export interface User {
   freeTier: string;
   soloRank: number;
   freeRank: number;
-  // mannerLevel: number;
-  // mannerRank?: null | number;
-  // mannerRatingCount?: number;
   updatedAt: string;
   mainP: Position;
   subP: Position;
@@ -57,13 +45,6 @@ export interface GameStyleList {
   gameStyleId: number;
   gameStyleName: string;
 }
-
-// export interface ChampionList {
-//   championId: number;
-//   championName: string;
-//   winRate: number;
-//   games: number;
-// }
 
 export interface UserInfo {
   id: number;

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -1,5 +1,5 @@
 import { GameStyleList } from '@/interface/profile';
-import { ChampionResponseDTO } from '@/types/api/board/board';
+import { ChampionResponseDTO } from '@/types/api/champion/champion';
 import { Position } from '@/types/position/position';
 import { Mike } from '@/types/user/mike';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';

--- a/src/types/api/board/board.d.ts
+++ b/src/types/api/board/board.d.ts
@@ -2,17 +2,9 @@ import { Position } from "@/types/position/position";
 import { ApiResponse } from "../api";
 import { Mike } from "@/types/user/mike";
 import { GameMode } from "@/types/game/gameMode";
+import { ChampionResponseDTO } from "../champion/champion";
 
 // 기본 DTO 인터페이스들
-interface ChampionResponseDTO {
-  championId: number;
-  championName: string;
-  csPerMinute: number;
-  games: number;
-  winRate: number;
-  wins: number;
-}
-
 export interface MannerKeywordDTO {
   createdAt: string;
   updatedAt: string;
@@ -46,8 +38,7 @@ interface GameInfo {
 interface GameStats {
   winRate: number;
   recentGameCount?: number;
-  championResponseList?: ChampionResponseDTO[];
-  championResponseDTOList?: ChampionResponseDTO[];
+  championStatsResponseList?: ChampionResponseDTO[];
 }
 
 // 기본 게시글 정보 인터페이스

--- a/src/types/api/champion/champion.ts
+++ b/src/types/api/champion/champion.ts
@@ -1,0 +1,11 @@
+{
+  /* TODO: 추후 프로필 쪽 csPerMinute, wins 값 들어오면 수정 */
+}
+export interface ChampionResponseDTO {
+  championId: number;
+  championName: string;
+  csPerMinute?: number;
+  games: number;
+  winRate: number;
+  wins?: number;
+}


### PR DESCRIPTION
## 연관 이슈

close #236

<br/>

## 📁 작업 내용
- 게시판 포지션 필터링 오류 수정
- Champion 관련 타입 반영
- 프로필 페이지 내 매칭 프로세스바 삭제
- 말풍선 꼬리 위치 조정
<br/>

## 🖥 구현 결과 (선택)

https://github.com/user-attachments/assets/9f59e51f-b897-4984-8d45-80494deb515e

<br/>

