### PR TITLE
[Design] 매칭 프로필 UI 변경사항 적용, 내가 찾는 포지션 2개 설정

### DIFF
--- a/src/api/board/board.ts
+++ b/src/api/board/board.ts
@@ -12,6 +12,8 @@ import {
 } from "@/types/api/board/board";
 import { Position } from "@/types/position/position";
 import { GameMode } from "@/types/game/gameMode";
+import { notify } from "@/hooks/notify";
+import { BOARD } from "@/constants/messages";
 
 interface ListInterface {
   page: number;
@@ -26,10 +28,17 @@ export const postBoard = async (params: PostReq): Promise<PostsResponse> => {
   try {
     const response = await AuthAxios.post("/api/v2/posts", params);
     return response.data;
-  } catch (error) {
-    console.error("글쓰기 실패:", error);
-    throw error;
-  }
+} catch (error: any) {
+      console.error("글쓰기 실패:", error);
+      if (error.response.data.code === "BOARD_412") {
+        notify({
+          text: BOARD.MESSAGE.COOLTIME,
+          icon: "🚫",
+          type: "error",
+        });
+      }
+      throw error;
+    }
 };
 
 /* 게시글 목록 조회 */

--- a/src/app/matching/complete/page.tsx
+++ b/src/app/matching/complete/page.tsx
@@ -31,8 +31,10 @@ interface User {
   memberId: number;
   gameName: string;
   tag: string;
-  tier: string;
-  rank: number;
+  soloTier: string;
+  freeTier: string;
+  soloRank: number;
+  freeRank: number;
   mannerLevel: number;
   profileImg: number;
   gameMode: number;
@@ -60,8 +62,10 @@ const Complete = () => {
     memberId: 0,
     gameName: "",
     tag: "",
-    tier: "",
-    rank: 0,
+    soloTier: "",
+    freeTier: "",
+    soloRank: 0,
+    freeRank: 0,
     mannerLevel: 0,
     profileImg: 0,
     gameMode: 0,
@@ -76,8 +80,10 @@ const Complete = () => {
     memberId: 0,
     gameName: "",
     tag: "",
-    tier: "",
-    rank: 0,
+    soloTier: "",
+    freeTier: "",
+    soloRank: 0,
+    freeRank: 0,
     mannerLevel: 0,
     profileImg: 0,
     gameMode: 0,
@@ -187,8 +193,11 @@ const Complete = () => {
           memberId: profileData.id,
           gameName: profileData.gameName,
           tag: profileData.tag,
-          tier: profileData.tier,
-          rank: profileData.gameRank,
+          // TODO: profileData로부터 solo & free 티어 및 랭크 받아오기
+          soloTier: profileData.tier,
+          freeTier: profileData.tier,
+          soloRank: profileData.gameRank,
+          freeRank: profileData.gameRank,
           mannerLevel: profileData.mannerLevel,
           profileImg: profileData.profileImg,
           gameMode: 0,

--- a/src/app/matching/progress/page.tsx
+++ b/src/app/matching/progress/page.tsx
@@ -24,8 +24,10 @@ interface User {
   memberId: number;
   gameName: string;
   tag: string;
-  tier: string;
-  rank: number;
+  soloTier: string;
+  freeTier: string;
+  soloRank: number;
+  freeRank: number;
   mannerLevel: number;
   profileImg: number;
   gameMode: number;
@@ -57,8 +59,11 @@ const Progress = () => {
     memberId: parseInt(searchParams.get("memberId") || "0", 10),
     gameName: searchParams.get("gameName") || "",
     tag: searchParams.get("tag") || "",
-    tier: searchParams.get("tier") || "",
-    rank: parseInt(searchParams.get("rank") || "1", 10),
+    /* TODO : 솔랭, 자랭 값으로 정보 얻어오도록 수정 */
+    soloTier: searchParams.get("tier") || "",
+    freeTier: searchParams.get("tier") || "",
+    soloRank: parseInt(searchParams.get("rank") || "1", 10),
+    freeRank: parseInt(searchParams.get("rank") || "1", 10),
     mannerLevel: parseInt(searchParams.get("mannerLevel") || "0", 10),
     profileImg: parseInt(searchParams.get("profileImg") || "0", 10),
     gameMode: parseInt(searchParams.get("gameMode") || "1", 10),
@@ -86,7 +91,9 @@ const Progress = () => {
         messages[Math.floor(Math.random() * messages.length)];
       /* 나와 같은 티어의 매칭 인원이 필요할 때 */
       if (messagesWithN[1] === randomMessage) {
-        const response = await getSystemMsg(user.tier);
+        /* TODO : 기획사항에 맞게 올바른 티어 전달하기 */
+        // const response = await getSystemMsg(user.tier);
+        const response = await getSystemMsg(user.soloTier); // 임시로 솔로티어로 전달
         setCurrentMessage(
           randomMessage.replace(/n/g, response.result.number.toString())
         );
@@ -247,7 +254,9 @@ const Progress = () => {
           page: 1,
           pageIdx: 1,
           gameMode: mode,
-          tier: user.tier,
+          /* TODO : 기획사항에 맞게 올바른 티어 전달하기 */
+          // tier: user.tier,
+          tier: user.soloTier, // 임시로 솔로티어로 전달
           mainP: user.mainPosition,
           mike: user.mike,
         };

--- a/src/components/common/Box.tsx
+++ b/src/components/common/Box.tsx
@@ -59,6 +59,8 @@ const StyledBox = styled.div<{ $shape: ShapeType; $profiletype?: profileType }>`
     css`
       height: 34px;
       padding: 6px 20px;
+      background: ${theme.colors.violet200};
+      color: ${theme.colors.gray800};
       ${(props) => props.theme.fonts.semiBold14}
       @media (max-width: 700px) {
         ${theme.fonts.semiBold13};

--- a/src/components/common/PositionCategory.tsx
+++ b/src/components/common/PositionCategory.tsx
@@ -1,5 +1,5 @@
 import { theme } from "@/styles/theme";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import React, { useEffect } from "react";
 import { Position, PositionType } from "@/types/position/position";
 import Image from "next/image";
@@ -14,8 +14,9 @@ import useMediaQueries from "@/hooks/useMediaQueries";
 
 interface PositionComponentProps {
   selectedBox?: PositionType | null;
-  value?: Position | (Position | null)[];
-  onSelect: (selectedValues: Position | (Position | null)[]) => void;
+  value?: Position | null;
+  // onSelect: (selectedValues: Position | (Position | null)[]) => void;
+  onSelect: (selectedValue: Position | null) => void;
   onClose: () => void;
 }
 
@@ -25,33 +26,16 @@ const PositionCategory = (props: PositionComponentProps) => {
   const boxRef = React.useRef<HTMLDivElement>(null);
 
   const handlePositionCategory = (positionName: Position | null) => {
-    let updatedValues: Position | (Position | null)[];
+    let updatedValue: Position | null;
 
-    if (selectedBox === "want") {
-      // 찾는 포지션 (want) → 최대 2개 선택 가능
-      let wantArray = Array.isArray(value) ? [...value] : [];
-
-      // 이미 선택된 경우 → 제거
-      if (wantArray.includes(positionName)) {
-        updatedValues = wantArray.filter((v) => v !== positionName);
-      } else if (wantArray.length < 2 || wantArray.includes(null)) {
-        // 최대 2개 선택 가능
-        const firstEmptyIndex = wantArray.indexOf(null);
-        if (firstEmptyIndex !== -1) {
-          wantArray[firstEmptyIndex] = positionName;
-        } else {
-          wantArray.push(positionName);
-        }
-        updatedValues = wantArray.slice(0, 2);
-      } else {
-        updatedValues = wantArray;
-      }
+    // 내가 찾는 포지션: 이미 선택한 포지션을 다시 클릭한 경우 → 해제
+    if (selectedBox === "want" && value === positionName) {
+      updatedValue = null;
     } else {
-      // 주/부 포지션 (main, sub) → 하나만 선택 가능
-      updatedValues = positionName || "ANY";
+      updatedValue = positionName ?? "ANY";
     }
 
-    onSelect(updatedValues);
+    onSelect(updatedValue);
   };
 
   const handleClose = () => {
@@ -100,7 +84,7 @@ const PositionCategory = (props: PositionComponentProps) => {
   const positionList = selectedBox === "want" ? POSITION.slice(1) : POSITION;
 
   return (
-    <Wrapper>
+    <Wrapper $isWant={selectedBox === "want"}>
       <Header>
         <Title>
           {selectedBox === "main"
@@ -126,19 +110,9 @@ const PositionCategory = (props: PositionComponentProps) => {
             key={pos.id}
             $posKey={pos.key}
             onClick={() => handlePositionCategory(pos.key)}
+            $selected={value === pos.key}
           >
-            {value.includes(pos.key) ? (
-              <>
-                <Image
-                  src={getImageSrc(pos.key)}
-                  alt={pos.key || "선택"}
-                  width={25}
-                  height={25}
-                />
-              </>
-            ) : (
-              getSvgComponent(pos.key)
-            )}
+            {getSvgComponent(pos.key)}
           </StyledButton>
         ))}
       </Box>
@@ -148,10 +122,10 @@ const PositionCategory = (props: PositionComponentProps) => {
 
 export default PositionCategory;
 
-const Wrapper = styled.div`
-  width: 452px;
+const Wrapper = styled.div<{ $isWant: boolean }>`
+  width: ${({ $isWant }) => ($isWant ? "383px" : "452px")};
   position: absolute;
-  top: 100px;
+  top: 70px;
   left: calc(50% - 35px);
   z-index: 10;
   border-radius: 20px;
@@ -164,6 +138,11 @@ const Wrapper = styled.div`
 
   @media (max-width: 700px) {
     width: 224px;
+    ${({ $isWant }) =>
+      $isWant &&
+      css`
+        left: calc(50% - 165px);
+      `};
   }
 `;
 
@@ -196,6 +175,14 @@ const Box = styled.div<{ $isWant: boolean }>`
     position: absolute;
     top: -18px;
     left: 27px;
+
+    @media (max-width: 700px) {
+      ${({ $isWant }) =>
+        $isWant &&
+        css`
+          left: 150px;
+        `};
+    }
   }
 
   @media (max-width: 700px) {
@@ -207,12 +194,16 @@ const Box = styled.div<{ $isWant: boolean }>`
   }
 `;
 
-const StyledButton = styled.button<{ $posKey: Position }>`
+const StyledButton = styled.button<{ $posKey: Position; $selected: boolean }>`
   width: 48px;
   height: 48px;
-  /* TODO */
-  /* background: ${(props) => (props.$posKey ? theme.colors.violet600 : "")}; */
-  border: none;
-  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${(props) =>
+    props.$selected ? theme.colors.violet600 : "transparent"};
+  border-radius: 6px;
+  padding-top: 2px;
+  padding-left: 1px;
   cursor: pointer;
 `;

--- a/src/components/common/PositionCategory.tsx
+++ b/src/components/common/PositionCategory.tsx
@@ -125,7 +125,7 @@ export default PositionCategory;
 const Wrapper = styled.div<{ $isWant: boolean }>`
   width: ${({ $isWant }) => ($isWant ? "383px" : "452px")};
   position: absolute;
-  top: 70px;
+  top: 80px;
   left: calc(50% - 35px);
   z-index: 10;
   border-radius: 20px;

--- a/src/components/common/RankTier.tsx
+++ b/src/components/common/RankTier.tsx
@@ -57,7 +57,7 @@ const RankName = styled.div<{ $direct: string }>`
   ${({ $direct }) =>
     $direct === "row" &&
     css`
-      ${theme.fonts.medium11}
+      ${theme.fonts.bold13}
     `}
     @media (max-width: 700px) {
     ${theme.fonts.medium11}
@@ -75,7 +75,7 @@ const Tier = styled.div<{ $direct: string }>`
     $direct === "row" &&
     css`
       color: ${theme.colors.gray600};
-      ${theme.fonts.semiBold13}
+      ${theme.fonts.bold14}
     `}
     @media (max-width: 700px) {
     ${theme.fonts.bold14}

--- a/src/components/crBoard/CRModal.tsx
+++ b/src/components/crBoard/CRModal.tsx
@@ -81,7 +81,7 @@ const Wrapper = styled.div<{
   margin: 50px;
   padding: 24px 30px;
   background: ${({ $hideContent }) =>
-    $hideContent ? "unset" : `${theme.colors.white}`};
+    $hideContent ? "unset" : `${theme.colors.gray100}`};
   box-shadow: ${({ $hideContent }) =>
     $hideContent ? "unset" : "0 4px 96.4px 0 #00000040"};
 

--- a/src/components/crBoard/PositionBox.tsx
+++ b/src/components/crBoard/PositionBox.tsx
@@ -95,7 +95,6 @@ const PositionBox = (props: PositionBoxProps) => {
     handlePositionClose(type, index);
   };
 
-  console.log("ㅋㅋㅋ", positionValue?.want);
   return (
     <PositionWrapper>
       <Positions>

--- a/src/components/crBoard/PositionBox.tsx
+++ b/src/components/crBoard/PositionBox.tsx
@@ -5,6 +5,10 @@ import PositionCategory from "../common/PositionCategory";
 import { Position, PositionType } from "@/types/position/position";
 import { theme } from "@/styles/theme";
 import { POSITION } from "@/constants/position";
+import { POSITIONS } from "@/constants/profile";
+import useMediaQueries from "@/hooks/useMediaQueries";
+import { setPositionImg } from "@/utils/custom";
+import { css } from "styled-components";
 
 type Status = "reading" | "posting";
 
@@ -24,136 +28,153 @@ export interface PositionState {
 
 const PositionBox = (props: PositionBoxProps) => {
   const { status, onPositionChange, main, sub, want } = props;
-  const [selectedBox, setSelectedBox] = useState<PositionType | null>(null);
-  const [openPosition, setOpenPosition] = useState<PositionType | null>(null);
+
+  const isMobile = useMediaQueries({ breakpoint: 700 });
   const [positionValue, setPositionValue] = useState<PositionState>({
     main: main || "ANY",
     sub: sub || "ANY",
-    want: want ?? [],
+    want: want || [null, null],
+  });
+
+  const [isPositionOpen, setIsPositionOpen] = useState({
+    main: false,
+    sub: false,
+    want: [false, false],
   });
 
   /* 포지션 선택  */
-  const handleCategoryButtonClick = (
-    selectedValues: Position | (Position | null)[]
-  ) => {
-    setPositionValue((prev) => {
-      let updated;
-
-      if (selectedBox === "want") {
-        // `want`는 배열 형태로 유지 (최대 2개 선택 가능)
-        updated = {
-          ...prev,
-          want: Array.isArray(selectedValues)
-            ? selectedValues
-            : [selectedValues],
-        };
-        console.log(updated);
+  const handlePosition = (type: "main" | "sub" | "want", index: number = 0) => {
+    if (status === "reading") return;
+    setIsPositionOpen((prev) => {
+      if (type === "want") {
+        const updated = prev.want.map((v, i) => (i === index ? !v : false));
+        return { ...prev, want: updated, main: false, sub: false };
       } else {
-        // `main`과 `sub`은 단일 값만 저장
-        updated = {
-          ...prev,
-          [selectedBox as "main" | "sub"]: selectedValues as Position,
-        };
+        return { ...prev, [type]: !prev[type], want: [false, false] };
       }
-
-      onPositionChange && onPositionChange(updated);
-      return updated;
     });
   };
 
-  const handlePositionImgSet = (positionId: Position | undefined | null) => {
-    // console.log("handlePositionImgSet", positionId);
-    const positionData = POSITION.find((p) => p.key === positionId);
-    if (!positionData || !positionData.image)
-      return "/assets/icons/bottom_caution.svg";
-    return `/assets/images/position/position_${positionData.image}_purple.svg`;
+  const handlePositionClose = (
+    type: "main" | "sub" | "want",
+    index: number = 0
+  ) => {
+    setIsPositionOpen((prev) => {
+      if (type === "want") {
+        const updated = [...prev.want];
+        updated[index] = false;
+        return { ...prev, want: updated };
+      } else {
+        return { ...prev, [type]: false };
+      }
+    });
   };
 
-  const handleBoxClick = (position: PositionType) => {
-    if (status === "reading") return;
-    setOpenPosition((prevPosition) =>
-      prevPosition === position ? null : position
-    );
-    setSelectedBox(position);
+  const handleCategoryButtonClick = (
+    selectedValue: Position | null,
+    type: "main" | "sub" | "want",
+    index: number = 0
+  ) => {
+    setPositionValue((prev) => {
+      const updated = { ...prev };
+
+      if (type === "want") {
+        const updatedWant = [...(prev.want ?? [null, null])];
+        updatedWant[index] =
+          updatedWant[index] === selectedValue ? null : selectedValue;
+        updated.want = updatedWant;
+      } else {
+        if (selectedValue === null) return prev; // main/sub에 null 불가
+        updated[type] = selectedValue;
+      }
+
+      onPositionChange?.(updated);
+      return updated;
+    });
+
+    handlePositionClose(type, index);
   };
 
-  const closePosition = () => {
-    setOpenPosition(null);
-  };
-
+  console.log("ㅋㅋㅋ", positionValue?.want);
   return (
     <PositionWrapper>
-      <FirstBox>
-        <Section>
-          <Title>주 포지션</Title>
-          <StyledImage
-            $status={status}
-            onClick={() => handleBoxClick("main")}
-            src={handlePositionImgSet(positionValue.main)}
-            width={35}
-            height={34}
-            alt="메인 포지션"
-          />
-          {openPosition === "main" && (
-            <PositionCategory
-              selectedBox={selectedBox}
-              onClose={closePosition}
-              value={positionValue.main}
-              onSelect={handleCategoryButtonClick}
-            />
-          )}
-        </Section>
-        <Section>
-          <Title>부 포지션</Title>
-          <StyledImage
-            $status={status}
-            onClick={() => handleBoxClick("sub")}
-            src={handlePositionImgSet(positionValue.sub)}
-            width={35}
-            height={34}
-            alt="부 포지션"
-          />
-          {openPosition === "sub" && (
-            <PositionCategory
-              selectedBox={selectedBox}
-              onClose={closePosition}
-              value={positionValue.sub}
-              onSelect={handleCategoryButtonClick}
-            />
-          )}
-        </Section>
-      </FirstBox>
-      <SecondBox>
-        <Title>찾는 포지션</Title>
-        <WantPWrapper>
-          <StyledImage
-            $status={status}
-            onClick={() => handleBoxClick("want")}
-            src={handlePositionImgSet(positionValue.want?.[0])}
-            width={35}
-            height={34}
-            alt="첫 번째 찾는 포지션"
-          />
-          {(positionValue.want?.[1] || status === "posting") && (
-            <StyledImage
-              $status={status}
-              onClick={() => handleBoxClick("want")}
-              src={handlePositionImgSet(positionValue.want?.[1])}
-              width={35}
-              height={34}
-              alt="두 번째 찾는 포지션"
-            />
-          )}
-          {openPosition === "want" && (
-            <PositionCategory
-              selectedBox={selectedBox}
-              onClose={closePosition}
-              value={positionValue.want || []}
-              onSelect={handleCategoryButtonClick}
-            />
-          )}
-        </WantPWrapper>
-      </SecondBox>
+      <Positions>
+        {/* 주 포지션 + 부 포지션 */}
+        <PosiWrap>
+          {POSITIONS.slice(0, 2).map((position, index) => {
+            const type = index === 0 ? "main" : "sub";
+
+            return (
+              <Posi key={index} $isWantP={false}>
+                {position.label}
+                <PosiItem>
+                  <Image
+                    src={setPositionImg(
+                      type === "main"
+                        ? positionValue.main ?? "ANY"
+                        : positionValue.sub ?? "ANY"
+                    )}
+                    width={!isMobile ? 55 : 22}
+                    height={!isMobile ? 40 : 22}
+                    alt="포지션"
+                    onClick={() => handlePosition(type)}
+                  />
+                  {isPositionOpen[type] && (
+                    <PositionCategory
+                      selectedBox={type}
+                      value={positionValue[type] ?? "ANY"}
+                      onClose={() => handlePositionClose(type)}
+                      onSelect={(val) => handleCategoryButtonClick(val, type)}
+                    />
+                  )}
+                </PosiItem>
+              </Posi>
+            );
+          })}
+        </PosiWrap>
+
+        {/* 내가 찾는 포지션 */}
+        <PosiWrap>
+          <Posi key={2} $isWantP={true}>
+            {POSITIONS[2].label}
+            <PosiRow>
+              {positionValue?.want?.map((posi, index) => (
+                <PosiItem key={index}>
+                  {posi ? (
+                    <Image
+                      src={setPositionImg(posi)}
+                      width={!isMobile ? 48 : 22}
+                      height={!isMobile ? 40 : 22}
+                      alt="포지션"
+                      onClick={() => handlePosition("want", index)}
+                    />
+                  ) : (
+                    <Plus onClick={() => handlePosition("want", index)}>
+                      <Image
+                        src="/assets/icons/plus_violet.svg"
+                        width={!isMobile ? 16 : 14}
+                        height={!isMobile ? 16 : 14}
+                        alt=""
+                      />
+                    </Plus>
+                  )}
+                  {/* PositionCategory 열기 조건 */}
+                  {isPositionOpen.want[index] && (
+                    <PositionCategory
+                      selectedBox="want"
+                      value={posi}
+                      onClose={() => handlePositionClose("want", index)}
+                      onSelect={(val) =>
+                        handleCategoryButtonClick(val, "want", index)
+                      }
+                    />
+                  )}
+                </PosiItem>
+              ))}
+            </PosiRow>
+          </Posi>
+        </PosiWrap>
+      </Positions>
     </PositionWrapper>
   );
 };
@@ -167,42 +188,75 @@ const PositionWrapper = styled.div`
   gap: 12px;
 `;
 
-const FirstBox = styled.div`
+const Positions = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
-  white-space: nowrap;
-  background: ${theme.colors.gray100};
-  border-radius: 10px;
-  padding: 24px 54px 24px 47px;
-  gap: 59px;
+  gap: 12px;
 `;
 
-const Section = styled.div`
-  position: relative;
-`;
-
-const SecondBox = styled.div`
-  text-align: center;
-  background: ${theme.colors.gray100};
-  white-space: nowrap;
-  border-radius: 10px;
-  padding: 24px 91px;
-  position: relative;
-`;
-
-const WantPWrapper = styled.div`
+const PosiWrap = styled.div`
+  height: 98px;
   display: flex;
+  justify-content: center;
+  gap: 58px;
+  background-color: ${theme.colors.white};
+  width: 100%;
+  border-radius: 6px;
+  padding: 16px 43px;
+
+  @media (max-width: 700px) {
+    height: 69px;
+    padding: 12px 20px 8px 20px;
+  }
+`;
+
+const Posi = styled.div<{ $isWantP: boolean }>`
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 30px;
+  font-size: ${theme.fonts.bold12};
+  color: ${theme.colors.gray700};
+
+  @media (max-width: 700px) {
+    font-size: ${theme.fonts.medium11};
+    gap: 9px;
+    ${({ $isWantP }) =>
+      $isWantP &&
+      css`
+        margin-left: 0px;
+      `};
+  }
 `;
 
-const Title = styled.p`
-  color: ${theme.colors.gray800};
-  ${(props) => props.theme.fonts.medium11};
-  margin-bottom: 6px;
+const PosiRow = styled.div`
+  height: 48px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
 `;
 
-const StyledImage = styled(Image)<{ $status: string | undefined }>`
-  cursor: ${({ $status }) => ($status === "posting" ? "pointer" : "unset")};
+const PosiItem = styled.div`
+  height: 48px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+`;
+
+const Plus = styled.div`
+  display: flex;
+  width: 48px;
+  height: 32px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 999px;
+  background: ${theme.colors.violet100};
+
+  @media (max-width: 700px) {
+    width: 32px;
+    height: 24px;
+  }
 `;

--- a/src/components/createBoard/PostBoard.tsx
+++ b/src/components/createBoard/PostBoard.tsx
@@ -29,6 +29,8 @@ import { getMyProfile } from "@/api/user/profile/get";
 import { Mike } from "@/types/user/mike";
 import { GAME_MODE } from "@/constants/board";
 import { GameMode } from "@/types/game/gameMode";
+import { Position } from "@/types/position/position";
+import { notify } from "@/hooks/notify";
 
 interface PostBoardProps {
   onClose: () => void;
@@ -232,8 +234,8 @@ const PostBoard = (props: PostBoardProps) => {
       wantP: isARAM
         ? ["ANY"]
         : Array.isArray(positionValue?.want)
-        ? positionValue?.want.length > 0
-          ? positionValue?.want
+        ? positionValue.want.filter((p): p is Position => p !== null).length > 0
+          ? positionValue.want.filter((p): p is Position => p !== null)
           : ["ANY"]
         : ["ANY"],
     };
@@ -242,7 +244,7 @@ const PostBoard = (props: PostBoardProps) => {
     if (currentPost) {
       try {
         await handleEdit(params);
-      } catch (error) {
+      } catch (error: any) {
         console.error(error);
       }
     }
@@ -333,10 +335,12 @@ const PostBoard = (props: PostBoardProps) => {
               sub={positionValue?.sub || null}
               want={
                 Array.isArray(positionValue?.want) &&
-                positionValue.want.length === 1 &&
-                positionValue.want[0] === "ANY"
-                  ? []
-                  : positionValue?.want || null
+                positionValue?.want.length === 2
+                  ? positionValue?.want
+                  : Array.isArray(positionValue?.want) &&
+                    positionValue?.want.length === 1
+                  ? [positionValue?.want[0], null]
+                  : [null, null]
               }
             />
           </PositionSection>

--- a/src/components/match/Profile.tsx
+++ b/src/components/match/Profile.tsx
@@ -79,11 +79,11 @@ const Profile: React.FC<Profile> = ({
   const [reportDetail, setReportDetail] = useState<string>("");
 
   /* 포지션 */
-  const [isPositionOpen, setIsPositionOpen] = useState<boolean[]>([
-    false,
-    false,
-    false,
-  ]);
+  const [isPositionOpen, setIsPositionOpen] = useState({
+    main: false,
+    sub: false,
+    want: [false, false], // 최대 2개의 want 포지션
+  });
   const [selectedBox, setSelectedBox] = useState("");
   const [showAlert, setShowAlert] = useState(false);
   const matchInfo = useSelector((state: RootState) => state.matchInfo);
@@ -93,7 +93,7 @@ const Profile: React.FC<Profile> = ({
   const [positionValue, setPositionValue] = useState<PositionState>({
     main: user.mainP,
     sub: user.subP,
-    want: user.wantP,
+    want: [null, null],
   });
   /* 선택된 현재 프로필 이미지 */
   const [selectedImageIndex, setSelectedImageIndex] = useState<number>(
@@ -106,7 +106,7 @@ const Profile: React.FC<Profile> = ({
     setPositionValue({
       main: user.mainP,
       sub: user.subP,
-      want: user.wantP, // 나중에 wantP값 받아서 수정
+      want: [null, null], // 나중에 wantP값 받아서 수정
     });
     setSelectedImageIndex(user.profileImg);
   }, [user]);
@@ -203,28 +203,53 @@ const Profile: React.FC<Profile> = ({
 
   /* 포지션 선택창 관련 함수*/
   // 포지션 선택창 열기 (포지션 클릭시 동작)
-  const handlePosition = async (index: number) => {
-    // console.log(index, "=====", profileType);
-    if (profileType !== "other") {
-      setIsPositionOpen((prev) =>
-        prev.map((isOpen, i) => (i === index ? !isOpen : false))
-      );
-      setSelectedBox(index === 0 ? "main" : index === 1 ? "sub" : "want");
-    }
+  const handlePosition = (type: "main" | "sub" | "want", index: number = 0) => {
+    if (profileType === "other") return;
+
+    setSelectedBox(type);
+
+    setIsPositionOpen((prev) => {
+      if (type === "want") {
+        const updatedWant = prev.want.map((open, i) =>
+          i === index ? !open : false
+        );
+        return {
+          ...prev,
+          want: updatedWant,
+          main: false,
+          sub: false,
+        };
+      } else {
+        return {
+          ...prev,
+          [type]: !prev[type],
+          want: [false, false],
+          ...(type === "main" ? { sub: false } : { main: false }),
+        };
+      }
+    });
   };
 
   // 포지션 선택창 닫기
-  const handlePositionClose = (index: number) => {
-    if (profileType !== "other") {
-      setIsPositionOpen((prev) =>
-        prev.map((isOpen, i) => (i === index ? false : isOpen))
-      );
-    }
+  const handlePositionClose = (
+    type: "main" | "sub" | "want",
+    index: number = 0
+  ) => {
+    if (profileType === "other") return;
+
+    setIsPositionOpen((prev) => {
+      if (type === "want") {
+        const updatedWant = [...prev.want];
+        updatedWant[index] = false;
+        return { ...prev, want: updatedWant };
+      } else {
+        return { ...prev, [type]: false };
+      }
+    });
   };
 
   // 포지션 선택해 변경하기
   const handlePositionChange = async (newPositionValue: PositionState) => {
-    // setPositionValue(newPositionValue);
     if (profileType === "me" && newPositionValue.main && newPositionValue.sub) {
       try {
         // 포지션 변경 API 호출
@@ -252,16 +277,23 @@ const Profile: React.FC<Profile> = ({
   };
 
   const handleCategoryButtonClick = (
-    selectedValues: Position | (Position | null)[]
+    selectedValue: Position | null,
+    type: "main" | "sub" | "want",
+    index: number = 0
   ) => {
-    if (selectedBox) {
-      const newPositionValue = {
-        ...positionValue,
-        [selectedBox]: selectedValues,
-      };
-      setPositionValue(newPositionValue);
-      handlePositionChange(newPositionValue);
+    let newPositionValue = { ...positionValue };
+
+    if (type === "want") {
+      const wantArray = [...(newPositionValue.want ?? [])];
+      wantArray[index] = selectedValue;
+      newPositionValue.want = wantArray;
+    } else {
+      if (selectedValue === null) return;
+      newPositionValue[type] = selectedValue;
     }
+
+    setPositionValue(newPositionValue);
+    handlePositionChange(newPositionValue);
   };
 
   const handleFriendState = async (state: string) => {
@@ -555,65 +587,83 @@ const Profile: React.FC<Profile> = ({
               <Positions>
                 {/* 주 포지션 + 부 포지션 */}
                 <PosiWrap>
-                  {POSITIONS.slice(0, 2).map((position, index) => (
-                    <Posi key={index} className={profileType} $isWantP={false}>
-                      {position.label}
-                      <Image
-                        src={setPositionImg(
-                          index === 0
-                            ? positionValue.main ?? "ANY"
-                            : index === 1
-                            ? positionValue.sub ?? "ANY"
-                            : (positionValue.want && positionValue.want[0]) ??
-                              "ANY"
-                        )}
-                        width={!isMobile ? 55 : 22}
-                        height={!isMobile ? 40 : 22}
-                        alt="포지션"
-                        onClick={() => handlePosition(index)}
-                      />
-                      {isPositionOpen[index] && (
-                        <PositionCategory
-                          selectedBox={index === 0 ? "main" : "sub"}
-                          value={
-                            index === 0
-                              ? positionValue.main ?? "ANY"
-                              : index === 1
-                              ? positionValue.sub ?? "ANY"
-                              : (positionValue.want && positionValue.want[0]) ??
-                                "ANY"
-                          }
-                          onClose={() => handlePositionClose(index)}
-                          onSelect={handleCategoryButtonClick}
-                        />
-                      )}
-                    </Posi>
-                  ))}
+                  {POSITIONS.slice(0, 2).map((position, index) => {
+                    const type = index === 0 ? "main" : "sub";
+
+                    return (
+                      <Posi
+                        key={index}
+                        className={profileType}
+                        $isWantP={false}
+                      >
+                        {position.label}
+                        <PosiItem>
+                          <Image
+                            src={setPositionImg(
+                              type === "main"
+                                ? positionValue.main ?? "ANY"
+                                : positionValue.sub ?? "ANY"
+                            )}
+                            width={!isMobile ? 55 : 22}
+                            height={!isMobile ? 40 : 22}
+                            alt="포지션"
+                            onClick={() => handlePosition(type)}
+                          />
+                          {isPositionOpen[type] && (
+                            <PositionCategory
+                              selectedBox={type}
+                              value={positionValue[type] ?? "ANY"}
+                              onClose={() => handlePositionClose(type)}
+                              onSelect={(val) =>
+                                handleCategoryButtonClick(val, type)
+                              }
+                            />
+                          )}
+                        </PosiItem>
+                      </Posi>
+                    );
+                  })}
                 </PosiWrap>
 
                 {/* 내가 찾는 포지션 */}
                 <PosiWrap>
                   <Posi key={2} className={profileType} $isWantP={true}>
                     {POSITIONS[2].label}
-                    <Image
-                      src={setPositionImg(
-                        (positionValue.want && positionValue.want[0]) ?? "ANY"
-                      )}
-                      width={!isMobile ? 55 : 22}
-                      height={!isMobile ? 40 : 22}
-                      alt="포지션"
-                      onClick={() => handlePosition(2)}
-                    />
-                    {isPositionOpen[2] && (
-                      <PositionCategory
-                        selectedBox="want"
-                        value={
-                          (positionValue.want && positionValue.want[0]) ?? "ANY"
-                        }
-                        onClose={() => handlePositionClose(2)}
-                        onSelect={handleCategoryButtonClick}
-                      />
-                    )}
+                    <PosiRow>
+                      {positionValue?.want?.map((posi, index) => (
+                        <PosiItem key={index}>
+                          {posi ? (
+                            <Image
+                              src={setPositionImg(posi)}
+                              width={!isMobile ? 48 : 22}
+                              height={!isMobile ? 40 : 22}
+                              alt="포지션"
+                              onClick={() => handlePosition("want", index)}
+                            />
+                          ) : (
+                            <Plus onClick={() => handlePosition("want", index)}>
+                              <Image
+                                src="/assets/icons/plus_violet.svg"
+                                width={!isMobile ? 16 : 14}
+                                height={!isMobile ? 16 : 14}
+                                alt=""
+                              />
+                            </Plus>
+                          )}
+                          {/* PositionCategory 열기 조건 */}
+                          {isPositionOpen.want[index] && (
+                            <PositionCategory
+                              selectedBox="want"
+                              value={posi}
+                              onClose={() => handlePositionClose("want", index)}
+                              onSelect={(val) =>
+                                handleCategoryButtonClick(val, "want", index)
+                              }
+                            />
+                          )}
+                        </PosiItem>
+                      ))}
+                    </PosiRow>
                   </Posi>
                 </PosiWrap>
               </Positions>
@@ -765,7 +815,6 @@ export default Profile;
 
 const Container = styled.div<{ $backgroundColor?: string }>`
   width: 100%;
-  /* height: 445px; */
   box-sizing: border-box;
   border-radius: 30px;
   padding: 45px;
@@ -1120,7 +1169,6 @@ const Posi = styled.div<{ $isWantP: boolean }>`
   align-items: center;
   font-size: ${theme.fonts.medium16};
   color: ${theme.colors.gray800};
-  position: relative;
 
   &.other {
     font-size: ${theme.fonts.medium16};
@@ -1134,6 +1182,37 @@ const Posi = styled.div<{ $isWantP: boolean }>`
       css`
         margin-left: 0px;
       `};
+  }
+`;
+
+const PosiRow = styled.div`
+  height: 40px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+`;
+
+const PosiItem = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+`;
+
+const Plus = styled.div`
+  display: flex;
+  width: 48px;
+  height: 32px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 999px;
+  background: ${theme.colors.violet100};
+
+  @media (max-width: 700px) {
+    width: 32px;
+    height: 24px;
   }
 `;
 

--- a/src/components/match/SquareProfile.tsx
+++ b/src/components/match/SquareProfile.tsx
@@ -12,13 +12,16 @@ import { toLowerCaseString } from "@/utils/string";
 import { Position as PositionType } from "@/types/position/position";
 import { Mike } from "@/types/user/mike";
 import useMediaQueries from "@/hooks/useMediaQueries";
+import RankTier from "../common/RankTier";
 
 interface User {
   memberId: number;
   gameName: string;
   tag: string;
-  tier: string;
-  rank: number;
+  soloTier: string;
+  freeTier: string;
+  soloRank: number;
+  freeRank: number;
   mannerLevel: number;
   profileImg: number;
   gameMode: number;
@@ -93,18 +96,19 @@ const SquareProfile: React.FC<SquareProfileProps> = ({
               <SpanTag>#{user.tag}</SpanTag>
             </FirstRow>
             <SecondRow>
-              <Rank>
-                <TierImage
-                  data={`/assets/images/tier/${
-                    user.tier !== "null"
-                      ? toLowerCaseString(user.tier)
-                      : "unrank"
-                  }.svg`}
-                  width={43}
-                  height={43}
-                />
-                {user.tier}
-              </Rank>
+              <RankTier
+                type="solo"
+                tier={user.soloTier}
+                rank={user.soloRank}
+                direct="row"
+              />
+              <Bar />
+              <RankTier
+                type="free"
+                tier={user.freeTier}
+                rank={user.freeRank}
+                direct="row"
+              />
             </SecondRow>
             <ImageContainer>
               <ProfileImgWrapper $bgColor={getProfileBgColor(user.profileImg)}>
@@ -131,7 +135,7 @@ const SquareProfile: React.FC<SquareProfileProps> = ({
             </ImageContainer>
             <Mic status={user.mike} />
             {/* TODO 게임 스타일 UI 확인 필요 */}
-            <RowBox>
+            <GameStyleContainer>
               {user.gameStyleList &&
                 user.gameStyleList.length > 0 &&
                 user.gameStyleList
@@ -144,7 +148,7 @@ const SquareProfile: React.FC<SquareProfileProps> = ({
                       text={item}
                     />
                   ))}
-            </RowBox>
+            </GameStyleContainer>
             <Row>
               <Position $opponent={opponent}>
                 {/* 주 포지션, 부 포지션 */}
@@ -245,6 +249,7 @@ const ImageContainer = styled.div`
   justify-content: center;
   position: relative;
   overflow-x: visible;
+  margin-bottom: 10px;
 `;
 
 const ProfileImgWrapper = styled.div<{ $bgColor: string }>`
@@ -273,11 +278,12 @@ const LevelTag = styled.span`
   transform: translate(-50%);
   height: 25px;
   border-radius: 57px;
-  padding: 6px 10px;
+  padding: 5px 10px;
   background: rgba(0, 0, 0, 0.64);
 
   color: ${theme.colors.violet300};
-  ${theme.fonts.bold13}
+  ${theme.fonts.bold13};
+  line-height: 13px;
   backdrop-filter: blur(7.5px);
 
   @media (max-width: 700px) {
@@ -357,9 +363,10 @@ const SpanTag = styled.span`
 
 const SecondRow = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
+  gap: 16px;
   color: ${theme.colors.gray800};
   ${(props) => props.theme.fonts.bold25};
 
@@ -370,15 +377,10 @@ const SecondRow = styled.div`
   }
 `;
 
-const Rank = styled.div`
-  display: flex;
-  align-items: center;
-  color: ${theme.colors.gray500};
-  ${(props) => props.theme.fonts.regular14};
-`;
-
-const TierImage = styled.object`
-  pointer-events: none;
+const Bar = styled.div`
+  width: 1px;
+  height: 12px;
+  background: ${theme.colors.gray400};
 `;
 
 const Row = styled.div`
@@ -389,8 +391,12 @@ const Row = styled.div`
   gap: 9px;
 `;
 
-const RowBox = styled(Row)`
-  /* gap: 18px; */
+const GameStyleContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
 `;
 
 const Position = styled.div<{ $opponent: boolean }>`
@@ -403,8 +409,9 @@ const Position = styled.div<{ $opponent: boolean }>`
   justify-content: center;
   align-items: center;
   gap: 33px;
-  ${theme.fonts.medium16};
+  ${theme.fonts.semiBold13};
   color: ${theme.colors.gray800};
+
   @media (max-width: 700px) {
     border-radius: 6px;
     padding: 12px 20px 8px 20px;
@@ -417,6 +424,7 @@ const Posi = styled.div<{ $opponent: boolean }>`
   flex-direction: column;
   gap: 15px;
   align-items: center;
+  white-space: nowrap;
 
   @media (max-width: 700px) {
     ${(props) =>

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -5,6 +5,12 @@ export const LOGIN = {
     },
   };
 
+export const BOARD = {
+    MESSAGE: {
+      COOLTIME: "게시글 작성 쿨타임이 적용되었습니다.\n5분 후 다시 시도해주세요.",
+    },
+  };
+
 
   export const messagesWithN = [
     "지금 n명이 매칭을 기다리고 있어요!",


### PR DESCRIPTION
## 연관 이슈

close #232 
<br/>

## 📁 작업 내용
- 매칭 프로필 UI 변경사항 적용
  - 솔로랭크, 자유랭크 반영 (`SquareProfile.tsx`)
  - CSS 수정 (`SquareProfile.tsx`)
  - 내가 찾는 포지션 2개 설정 (`Profile.tsx`, `PositionCategory.tsx`)
- 게시판 글작성 포지션 변경
  - CSS 수정
  - `PositionBox.tsx` 리팩토링, 포지션 선택 로직 수정 (매칭 프로필과 동일하게)
- 게시판 작성 시 쿨타임 오류 안내 메세지

<br/>

## 🖥 구현 결과 (선택)

https://github.com/user-attachments/assets/660498e3-0ee4-4e74-8b84-8cc205a12551


https://github.com/user-attachments/assets/6692c4d8-f089-43c2-8c9f-64ba2d1e8ffa

<br/>

## 📁 기타 사항

- 저번에 TODO로 남겨주신 포지션 선택 시 기존 선택 포지션의 경우 배경색 입히는 작업 이번에 내가 찾는 포지션 관련해서 작업하면서 같이 했습니다!
- 기존에 보라색 포지션 이미지에서 피그마처럼 변경된 이미지는 디자인 요청해서 수정 필요할 것 같습니다! 지금은 피그마에 두 개만 보이는 것 같은데.. (맞나요?) 제가 요청 후에 바꿔두겠습니다😃
![image](https://github.com/user-attachments/assets/61643e49-ff76-4e1a-942c-0f9a0fdc128a)

- 내가 찾는 포지션 변경 API가 지금 1개씩만 변경 가능하게 되어있는데, 기획 수정에 따라 2개로 바뀌면서 배열로 변경되게 이 부분도 수정 요청드릴 예정입니다! 지금 유저 프로필 조회에서 둘다 ++ 로 나오는데, 이후에 이 부분도 같이 수정하겠습니다.

- @ohofront  영호님! [9dc9387](https://github.com/Gamegoo-repo/Gamegoo-front/pull/240/commits/9dc93879925863accffbefc34e7203f3d5957d04) 해당 커밋 `/app/matcing/progress/page.tsx`에서 제가 SquareProfile에 솔랭 자랭 추가하면서 오류가 생겼는데, 임시로 기존에 전달되던 `tier`를 `soloTier`로 넣어두었습니다! TODO 주석 달아놓은 부분 영호님께서 작업해주실 부분이라 표시해두었어요. 게임모드에 따라서 반영되는 티어 기준 (solo/free)이 다른데, 기획서 보시면서 이 부분 반영 부탁드릴게요! 매칭 소켓에서 변경되는 부분에도 포함될 거예요.:)
<br/>

