### PR TITLE
[Feat] 새로고침 시 채팅 탭 유지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-helmet-async": "^2.0.5",
         "react-hot-toast": "^2.4.1",
         "react-redux": "^9.1.2",
+        "redux-persist": "^6.0.0",
         "socket.io": "^4.7.5",
         "socket.io-client": "^4.7.5",
         "styled-components": "^6.1.9"
@@ -33,6 +34,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/redux-persist": "^4.3.1",
         "babel-plugin-styled-components": "^2.1.4",
         "eslint": "^8",
         "eslint-config-next": "14.2.3",
@@ -2843,6 +2845,16 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/redux-persist": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/redux-persist/-/redux-persist-4.3.1.tgz",
+      "integrity": "sha512-YkMnMUk+4//wPtiSTMfsxST/F9Gh9sPWX0LVxHuOidGjojHtMdpep2cYvQgfiDMnj34orXyZI+QJCQMZDlafKA==",
+      "deprecated": "This is a stub types definition for redux-persist (https://github.com/rt2zz/redux-persist). redux-persist provides its own type definitions, so you don't need @types/redux-persist installed!",
+      "dev": true,
+      "dependencies": {
+        "redux-persist": "*"
       }
     },
     "node_modules/@types/stylis": {
@@ -6528,6 +6540,14 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-helmet-async": "^2.0.5",
     "react-hot-toast": "^2.4.1",
     "react-redux": "^9.1.2",
+    "redux-persist": "^6.0.0",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5",
     "styled-components": "^6.1.9"
@@ -34,6 +35,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/redux-persist": "^4.3.1",
     "babel-plugin-styled-components": "^2.1.4",
     "eslint": "^8",
     "eslint-config-next": "14.2.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import Header from "@/components/common/Header";
 import StyledComponentsRegistry from "@/libs/registry";
 import { useEffect, useRef, useState } from "react";
 import { Provider } from "react-redux";
-import { AppStore, store } from "@/redux/store";
+import { AppStore } from "@/redux/store";
 import { usePathname } from "next/navigation";
 import SocketConnection from "@/components/socket/SocketConnection";
 import { Toaster } from "react-hot-toast";
@@ -21,6 +21,9 @@ import {
 } from "@/utils/storage";
 import { notify } from "@/hooks/notify";
 import { GoogleAnalytics, GoogleTagManager } from "@next/third-parties/google";
+import { PersistGate } from "redux-persist/integration/react";
+import { store as createStore } from "@/redux/store";
+import { persistStore } from "redux-persist";
 
 export default function RootLayout({
   children,
@@ -28,11 +31,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const storeRef = useRef<AppStore>();
+  const [persistor, setPersistor] = useState<any>(null);
   const [isLoggedIn, setIsLoggedIn] = useState(!!getAccessToken());
 
   if (!storeRef.current) {
-    storeRef.current = store();
+    storeRef.current = createStore();
   }
+
+  // SSR-safe: 클라이언트에서만 persistor 생성
+  useEffect(() => {
+    const ps = persistStore(storeRef.current!);
+    setPersistor(ps);
+  }, []);
 
   const pathname = usePathname();
   const previousPathname = useRef(pathname);
@@ -84,7 +94,6 @@ export default function RootLayout({
     setIsLoggedIn(!!getAccessToken());
   }, [pathname]);
 
-  // 테스트용 주석
   return (
     <html>
       <head>
@@ -116,18 +125,24 @@ export default function RootLayout({
             <GlobalStyles />
             <ThemeProvider theme={theme}>
               <Toaster />
-              <Provider store={storeRef.current}>
-                <SocketConnection key={isLoggedIn ? "loggedIn" : "loggedOut"} />
-                <Container>
-                  <Main>
-                    {isHeaderFooterShow && <Header />}
-                    {children}
-                  </Main>
-                  {isHeaderFooterShow && (
-                    <Footer isShowChat={isHeaderFooterShow} />
-                  )}
-                </Container>
-              </Provider>
+              {persistor && (
+                <Provider store={storeRef.current}>
+                  <PersistGate loading={null} persistor={persistor}>
+                    <SocketConnection
+                      key={isLoggedIn ? "loggedIn" : "loggedOut"}
+                    />
+                    <Container>
+                      <Main>
+                        {isHeaderFooterShow && <Header />}
+                        {children}
+                      </Main>
+                      {isHeaderFooterShow && (
+                        <Footer isShowChat={isHeaderFooterShow} />
+                      )}
+                    </Container>
+                  </PersistGate>
+                </Provider>
+              )}
             </ThemeProvider>
           </StyledComponentsRegistry>
         </HelmetProvider>

--- a/src/components/chat/MessageHeader.tsx
+++ b/src/components/chat/MessageHeader.tsx
@@ -85,7 +85,7 @@ const MessageHeader = (props: MessageHeaderProps) => {
       )}
       <CloseButton>
         <CloseImage
-          onClick={() => dispatch(closeChat())}
+          onClick={() => dispatch(closeChatRoom())}
           src="/assets/icons/close.svg"
           width={11}
           height={11}

--- a/src/redux/slices/chatSlice.ts
+++ b/src/redux/slices/chatSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-interface ChatState {
+export interface ChatState {
     isChatOpen: boolean;
     isChatRoomOpen: boolean;
   isChatRoomUuid: string | number;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -11,6 +11,29 @@ import notiReducer from "./slices/notiSlice";
 import matchingReducer from "./slices/matchingSlice";
 import boardReducer from "./slices/boardSlice";
 import chatPositionReducer from "./slices/chatPositionSlice";
+import storage from "redux-persist/lib/storage";
+
+import {
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from "redux-persist";
+
+// chat reducer만 persist 적용
+const chatPersistConfig = {
+  key: "chat",
+  storage,
+  whitelist: ["activeTab"],
+};
+
+const persistedChatReducer = persistReducer(
+  chatPersistConfig,
+  chatReducer
+);
 
 export const store = () => {
   return configureStore({
@@ -22,12 +45,18 @@ export const store = () => {
       mannerStatus: mannerStatusReducer,
       post: postReducer,
       matchInfo: matchInfoReducer,
-      chat: chatReducer,
+      chat: persistedChatReducer,
       noti: notiReducer,
       matching: matchingReducer,
       board: boardReducer,
       chatPosition: chatPositionReducer,
     },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        serializableCheck: {
+          ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+        },
+      }),
   });
 }
 
@@ -35,5 +64,3 @@ export const store = () => {
 export type AppStore = ReturnType<typeof store>;
 export type RootState = ReturnType<AppStore['getState']>;
 export type AppDispatch = AppStore['dispatch'];
-
-export default store;


### PR DESCRIPTION
## 연관 이슈

close #239

<br/>

## 📁 작업 내용

- 채팅창 안 닫히는 오류 수정 (`closeChat` -> `closeChatRoom` 수정)
- chatSlice > activeTab에 `redux-persist` 적용해 새로고침 시에도 현재 탭 상태 유지되도록 수정

<br/>

## 🖥 구현 결과 (선택)

https://github.com/user-attachments/assets/b2fecea2-2577-479c-8425-40b86832c00d



<br/>

## 📁 기타 사항

- npm install로 redux-persist 설치 필요합니다!
<hr/>

### 설명
- middleware의 `serializableCheck`는 주로 개발 도중 직렬화 불가능한 데이터(예: 함수, Date, File 등)가 Redux 상태나 액션에 들어가는 걸 방지하기 위한 클라이언트 개발 환경용 설정
- `layout.tsx`에서 클라이언트에서만 persistor 생성되도록 `useEffect` 사용
<br/>
