### PR TITLE
[Design] 팝업 PC, MO 디자인 수정 적용

### DIFF
--- a/src/app/mypage/profile/page.tsx
+++ b/src/app/mypage/profile/page.tsx
@@ -119,6 +119,7 @@ const MyProfilePage = () => {
             secondaryButtonText="취소"
             onPrimaryClick={handleWithdrawal}
             onSecondaryClick={() => setIsWithdrawalCaution(false)}
+            type="withDrawer"
           >
             <ModalContent>
               <div>
@@ -263,8 +264,12 @@ const P = styled.button`
 `;
 
 const ModalContent = styled.div`
-  padding: 30px 0;
+  padding: 46px 0;
   display: flex;
   flex-direction: column;
   gap: 20px;
+
+  @media (max-width: 700px) {
+    padding: 35px 0;
+  }
 `;

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -2,12 +2,11 @@ import {
   setOpenEvaluationModal,
   setOpenModal,
 } from "@/redux/slices/modalSlice";
-import { theme } from "@/styles/theme";
 import Image from "next/image";
 import { useState } from "react";
 import { useDispatch } from "react-redux";
 import styled from "styled-components";
-
+import { theme } from "@/styles/theme";
 type ButtonText =
   | "취소"
   | "나가기"
@@ -23,7 +22,7 @@ type ButtonText =
   | "회원 탈퇴";
 
 interface ConfirmModalProps {
-  type?: "manner";
+  type?: "manner" | string;
   children?: string | React.ReactNode;
   width: string;
   primaryButtonText: ButtonText;
@@ -135,6 +134,7 @@ const ConfirmModal = (props: ConfirmModalProps) => {
                 !badMannerStatusClicked
               }
               $type={type}
+              $isRed={type === "withDrawer"}
             >
               {primaryButtonText}
             </Button>
@@ -167,7 +167,7 @@ const Overlay = styled.div<{ $type: string | undefined }>`
   align-items: center;
   position: fixed;
   background: #0000009c;
-  border-radius: ${({ $type }) => ($type ? "20px" : "unset")};
+  border-radius: ${({ $type }) => ($type === "manner" ? "20px" : "unset")};
   inset: 0;
   z-index: 101;
 `;
@@ -175,13 +175,19 @@ const Overlay = styled.div<{ $type: string | undefined }>`
 const Wrapper = styled.div<{ $width: string; $type: string | undefined }>`
   width: ${({ $width }) => $width};
   background: ${theme.colors.white};
-  border-radius: ${({ $type }) => ($type ? "10px" : "20px")};
+  border-radius: ${({ $type }) => ($type === "manner" ? "10px" : "20px")};
   box-shadow: 0 0 14.76px 0 rgba(0, 0, 0, 0.15);
   overflow: hidden;
+  @media (max-width: 700px) {
+    width: 90vw;
+  }
 `;
 
 const Main = styled.main`
   padding: 0 4px;
+  @media (max-width: 700px) {
+    padding: 0;
+  }
 `;
 
 const ImageTop = styled.div`
@@ -194,8 +200,14 @@ const TextTop = styled.div`
   align-items: center;
   justify-content: center;
   text-align: center;
-  border-bottom: 0.58px solid rgba(197, 197, 199, 1);
+  border-bottom: 0.58px solid ${theme.colors.gray400};
   ${(props) => props.theme.fonts.regular25};
+  color: ${theme.colors.gray800};
+
+  @media (max-width: 700px) {
+    min-height: 124px;
+    ${theme.fonts.medium14}
+  }
 `;
 
 const CloseButton = styled.p`
@@ -237,16 +249,23 @@ const ButtonWrapper = styled.div`
   justify-content: center;
 `;
 
-const Button = styled.button<{ $type: string | undefined }>`
+const Button = styled.button<{
+  $type: string | undefined;
+  $isRed?: boolean;
+}>`
   text-align: center;
   ${({ $type }) =>
-    $type ? `${theme.fonts.bold11}` : `${theme.fonts.semiBold18}`};
+    $type === "manner" ? `${theme.fonts.bold11}` : `${theme.fonts.semiBold18}`};
   cursor: pointer;
-  color: ${({ $type }) =>
-    $type ? `${theme.colors.gray600}` : `${theme.colors.gray700}`};
+  color: ${({ $type, $isRed }) =>
+    $type === "manner"
+      ? theme.colors.gray600
+      : $isRed
+      ? theme.colors.red600
+      : theme.colors.gray700};
   width: 100%;
   height: ${({ $type }) => ($type ? "none" : "79px")};
-  padding: 15px 0;
+  padding: 30px 0;
   &:disabled {
     color: ${theme.colors.gray300};
   }
@@ -279,5 +298,10 @@ const Button = styled.button<{ $type: string | undefined }>`
       background: ${theme.colors.gray100};
       border-radius: 0 0 20px 20px;
     }
+  }
+
+  @media (max-width: 700px) {
+    padding: 20px 0;
+    ${theme.fonts.semiBold14}
   }
 `;

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -303,5 +303,6 @@ const Button = styled.button<{
   @media (max-width: 700px) {
     padding: 20px 0;
     ${theme.fonts.semiBold14}
+    height: unset
   }
 `;


### PR DESCRIPTION
## 연관 이슈

close #246 

<br/>

## 📁 작업 내용

- '회원 탈퇴' 텍스트 컬러 변경 (red/600)
- 모바일 반응형 스타일 적용

<br/>

## 🖥 구현 결과 (선택)

![image](https://github.com/user-attachments/assets/3b78d65e-fc84-41eb-bcc9-f3955a1f3f6d)
![image](https://github.com/user-attachments/assets/41a50244-4afe-4b44-bdd1-387ec8b7fa51)
![image](https://github.com/user-attachments/assets/b7e38972-03f7-4540-81de-31652b9a5cd4)
![image](https://github.com/user-attachments/assets/682dc1b3-1fa9-4f50-81e7-f4f1016b832a)


<br/>

## ✔ 리뷰 요구사항
없습니다


<br/>

## 📁 기타 사항
딱히 없습니다!

<br/>
