### PR TITLE
[Feat] 내가 찾는 포지션 2개 변경 적용

### DIFF
--- a/src/components/common/PositionCategory.tsx
+++ b/src/components/common/PositionCategory.tsx
@@ -18,10 +18,17 @@ interface PositionComponentProps {
   // onSelect: (selectedValues: Position | (Position | null)[]) => void;
   onSelect: (selectedValue: Position | null) => void;
   onClose: () => void;
+  usedPositions?: Position[] | null;
 }
 
 const PositionCategory = (props: PositionComponentProps) => {
-  const { selectedBox, value = [], onSelect, onClose } = props;
+  const {
+    selectedBox,
+    value = [],
+    onSelect,
+    onClose,
+    usedPositions = [],
+  } = props;
   const isMobile = useMediaQueries({ breakpoint: 700 });
   const boxRef = React.useRef<HTMLDivElement>(null);
 
@@ -105,16 +112,21 @@ const PositionCategory = (props: PositionComponentProps) => {
       </Header>
 
       <Box $isWant={selectedBox === "want"} ref={boxRef}>
-        {positionList.map((pos) => (
-          <StyledButton
-            key={pos.id}
-            $posKey={pos.key}
-            onClick={() => handlePositionCategory(pos.key)}
-            $selected={value === pos.key}
-          >
-            {getSvgComponent(pos.key)}
-          </StyledButton>
-        ))}
+        {positionList.map((pos) => {
+          const isUsed = usedPositions?.includes(pos.key) && value !== pos.key;
+          return (
+            <StyledButton
+              key={pos.id}
+              $posKey={pos.key}
+              onClick={() => handlePositionCategory(pos.key)}
+              $selected={value === pos.key}
+              disabled={isUsed}
+              $isUsed={isUsed}
+            >
+              {getSvgComponent(pos.key)}
+            </StyledButton>
+          );
+        })}
       </Box>
     </Wrapper>
   );
@@ -194,7 +206,11 @@ const Box = styled.div<{ $isWant: boolean }>`
   }
 `;
 
-const StyledButton = styled.button<{ $posKey: Position; $selected: boolean }>`
+const StyledButton = styled.button<{
+  $posKey: Position;
+  $selected: boolean;
+  $isUsed?: boolean;
+}>`
   width: 48px;
   height: 48px;
   display: flex;
@@ -205,5 +221,6 @@ const StyledButton = styled.button<{ $posKey: Position; $selected: boolean }>`
   border-radius: 6px;
   padding-top: 2px;
   padding-left: 1px;
+  opacity: ${(props) => (props.$isUsed ? 0.4 : 1)};
   cursor: pointer;
 `;

--- a/src/components/crBoard/PositionBox.tsx
+++ b/src/components/crBoard/PositionBox.tsx
@@ -166,6 +166,12 @@ const PositionBox = (props: PositionBoxProps) => {
                       onSelect={(val) =>
                         handleCategoryButtonClick(val, "want", index)
                       }
+                      usedPositions={
+                        positionValue.want?.filter(
+                          (pos, i): pos is Position =>
+                            i !== index && pos !== null
+                        ) ?? []
+                      }
                     />
                   )}
                 </PosiItem>

--- a/src/components/match/Profile.tsx
+++ b/src/components/match/Profile.tsx
@@ -94,7 +94,7 @@ const Profile: React.FC<Profile> = ({
   const [positionValue, setPositionValue] = useState<PositionState>({
     main: user.mainP,
     sub: user.subP,
-    want: [null, null],
+    want: user.wantP,
   });
   /* 선택된 현재 프로필 이미지 */
   const [selectedImageIndex, setSelectedImageIndex] = useState<number>(
@@ -107,7 +107,7 @@ const Profile: React.FC<Profile> = ({
     setPositionValue({
       main: user.mainP,
       sub: user.subP,
-      want: [null, null], // 나중에 wantP값 받아서 수정
+      want: user.wantP, // 나중에 wantP값 받아서 수정
     });
     setSelectedImageIndex(user.profileImg);
   }, [user]);
@@ -251,7 +251,11 @@ const Profile: React.FC<Profile> = ({
 
   // 포지션 선택해 변경하기
   const handlePositionChange = async (newPositionValue: PositionState) => {
-    if (profileType === "me" && newPositionValue.main && newPositionValue.sub) {
+    if (
+      profileType !== "other" &&
+      newPositionValue.main &&
+      newPositionValue.sub
+    ) {
       try {
         // 포지션 변경 API 호출
         await putPosition({

--- a/src/components/match/Profile.tsx
+++ b/src/components/match/Profile.tsx
@@ -669,6 +669,12 @@ const Profile: React.FC<Profile> = ({
                               onSelect={(val) =>
                                 handleCategoryButtonClick(val, "want", index)
                               }
+                              usedPositions={
+                                positionValue.want?.filter(
+                                  (pos, i): pos is Position =>
+                                    i !== index && pos !== null
+                                ) ?? []
+                              }
                             />
                           )}
                         </PosiItem>

--- a/src/components/mypage/post/PositionBox.tsx
+++ b/src/components/mypage/post/PositionBox.tsx
@@ -166,6 +166,12 @@ const PositionBox = (props: PositionBoxProps) => {
                       onSelect={(val) =>
                         handleCategoryButtonClick(val, "want", index)
                       }
+                      usedPositions={
+                        positionValue.want?.filter(
+                          (pos, i): pos is Position =>
+                            i !== index && pos !== null
+                        ) ?? []
+                      }
                     />
                   )}
                 </PosiItem>


### PR DESCRIPTION
## 연관 이슈

close #257

<br/>

## 📁 작업 내용

- 내가 찾는 포지션 2개 변경 적용 (API 적용사항 반영)
- 내가 찾는 포지션 설정 시, 이전 선택값은 disable 처리 (opacity 조정)

<br/>

## 🖥 구현 결과 (선택)

https://github.com/user-attachments/assets/aa1f587d-fae0-4e22-8102-46b7c76a2e8c



![image](https://github.com/user-attachments/assets/7d02ddf6-7507-4137-a689-67daba211ccb)

<br/>


## 📁 기타 사항
- 게시판 글 작성시 포지션 초기값은 두번째 사진과 같습니다! 리덕스가 남아있어서 녹화본에서는 다르게 보여 헷갈리실까 첨부합니다.🙌🏻
<br/>
