### PR TITLE
[Fix] 매칭 중 동시 접속 인원 반영 오류 수정

### DIFF
--- a/src/app/match/profile/page.tsx
+++ b/src/app/match/profile/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Profile from "@/components/match/Profile";
 import Button from "@/components/common/Button";
 import HeaderTitle from "@/components/common/HeaderTitle";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { profileType } from "@/interface/profile";
 import { Suspense } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -34,6 +34,10 @@ const ProfilePage = () => {
   const dispatch = useDispatch();
   const user = useSelector((state: RootState) => state.user);
   const matchInfo = useSelector((state: RootState) => state.matchInfo);
+
+  const [tier, setTier] = useState<string>("UNRANK");
+  const [tierCounts, setTierCounts] = useState<Record<string, number>>({});
+  const tierCountsRef = useRef(tierCounts);
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -90,6 +94,24 @@ const ProfilePage = () => {
     }
   }, []);
 
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleMatchingCount = (data: any) => {
+      setTierCounts({ ...data.data.tierCount, total: data.data.userCount });
+    };
+
+    socket.on("matching-count", handleMatchingCount);
+    return () => {
+      socket?.off("matching-count", handleMatchingCount); // 메모리 누수 방지
+    };
+  }, [socket]);
+
+  useEffect(() => {
+    console.log("프로필 페이지에서 matching-count 수신", tierCounts);
+    tierCountsRef.current = tierCounts; // 항상 최신값 저장
+  }, [tierCounts]);
+
   const handleMatchStart = async () => {
     const matchingType = params === "gamegoo" ? "BASIC" : "PRECISE";
 
@@ -109,40 +131,55 @@ const ProfilePage = () => {
       socket.emit("matching-request", matchingData);
       console.log("매칭 요청 이벤트 발생:", matchingData);
 
+      let matchingStartedData: any = null;
+
       /* 매칭 시작 이벤트 */
       socket.on("matching-started", (data) => {
         console.log("매칭 시작됨:", data);
+        matchingStartedData = data.data;
 
-        const baseParams: Record<string, string> = {
-          matchingType: params || "",
-          gameRank: rank || "",
-        };
+        const handleMatchingCount = (data: any) => {
+          setTierCounts({
+            ...data.data.tierCount,
+            total: data.data.userCount,
+          });
 
-        if (retry) {
-          baseParams.retry = "true";
-        }
+          const baseParams: Record<string, string> = {
+            matchingType: params || "",
+            gameRank: rank || "",
+            tier: tier,
+            tierCounts: JSON.stringify(data.data),
+            ...matchingStartedData,
+          };
 
-        const rawData = data.data ?? {};
-        const formattedData: Record<string, string> = {};
-
-        // 각 필드를 순회하면서 문자열로 변환
-        for (const key in rawData) {
-          const value = rawData[key];
-          if (typeof value === "object") {
-            formattedData[key] = JSON.stringify(value); // 객체/배열은 JSON 문자열로
-          } else {
-            formattedData[key] = String(value); // 나머지는 그냥 문자열로
+          if (retry) {
+            baseParams.retry = "true";
           }
-        }
 
-        const combinedParams = {
-          ...formattedData,
-          ...baseParams,
+          const rawData = data.data ?? {};
+          const formattedData: Record<string, string> = {};
+
+          // 각 필드를 순회하면서 문자열로 변환
+          for (const key in rawData) {
+            const value = rawData[key];
+            if (typeof value === "object") {
+              formattedData[key] = JSON.stringify(value); // 객체/배열은 JSON 문자열로
+            } else {
+              formattedData[key] = String(value); // 나머지는 그냥 문자열로
+            }
+          }
+
+          const combinedParams = {
+            ...formattedData,
+            ...baseParams,
+          };
+
+          const urlParams = new URLSearchParams(combinedParams);
+
+          router.push(`/matching/progress?${urlParams.toString()}`);
         };
 
-        const urlParams = new URLSearchParams(combinedParams);
-
-        router.push(`/matching/progress?${urlParams.toString()}`);
+        socket?.on("matching-count", handleMatchingCount);
       });
 
       /* sender 입장에서 바로 매칭 상대 찾을 경우 처리 */

--- a/src/app/matching/complete/page.tsx
+++ b/src/app/matching/complete/page.tsx
@@ -59,6 +59,7 @@ const Complete = () => {
   );
   const type = searchParams.get("type");
   const rank = searchParams.get("rank");
+  const matchingUuid = searchParams.get("uuid");
   const [userMe, setUserMe] = useState<User>({
     memberId: 0,
     gameName: "",
@@ -258,7 +259,9 @@ const Complete = () => {
   // 타임아웃 처리
   const handleTimeout = () => {
     if (role === "receiver") {
-      socket?.emit("matching-success-receiver");
+      socket?.emit("matching-success-receiver", {
+        senderMatchingUuid: matchingUuid,
+      });
       startSecondaryTimer();
     }
   };

--- a/src/app/matching/progress/page.tsx
+++ b/src/app/matching/progress/page.tsx
@@ -94,6 +94,8 @@ const Progress = () => {
   const [currentMessage, setCurrentMessage] = useState<string>("");
   const [textVisible, setTextVisible] = useState<boolean>(true);
 
+  const thresholdRef = useRef(51.5);
+
   // const [showReloadModal, setShowReloadModal] = useState(false); // 새로고침 모달 상태
 
   useEffect(() => {
@@ -235,8 +237,8 @@ const Progress = () => {
     if (timerRef.current) return; // 이미 타이머가 실행 중이면 추가로 설정하지 않음
 
     // 매칭 재시도 여부에 따라 타이머 설정
-    setTimeLeft(300);
-    let threshold = 51.5; // 초기 threshold 값
+    thresholdRef.current = 51.5; // 초기 threshold 값
+
     timerRef.current = setInterval(() => {
       setTimeLeft((prevTime) => {
         if (prevTime === 1) {
@@ -246,11 +248,10 @@ const Progress = () => {
           handleRetry(); // 매칭 실패 모달 결정 함수
         } else if (prevTime < 300 && prevTime % 30 === 0) {
           // 30초마다 threshold 값을 감소시키며 매칭 재시도
-          threshold -= 1.5;
-          socket?.emit("matching-retry", { threshold });
-          console.log(`매칭 재시도 (priority: ${threshold})`);
+          thresholdRef.current -= 1.5;
+          socket?.emit("matching-retry", { threshold: thresholdRef.current });
+          console.log(`매칭 재시도 (priority: ${thresholdRef.current})`);
         }
-
         return prevTime - 1;
       });
     }, 1000);

--- a/src/app/matching/progress/page.tsx
+++ b/src/app/matching/progress/page.tsx
@@ -27,6 +27,7 @@ import { getEffectiveTier } from "@/utils/matching/tier";
 import { GameMode } from "@/types/game/gameMode";
 import { GameStyleList } from "@/interface/profile";
 import WaitingBox from "@/components/match/WaitingBox";
+import { GAME_STYLE } from "@/constants/profile";
 
 interface User {
   memberId: number;
@@ -63,7 +64,7 @@ const Progress = () => {
   const rank = searchParams.get("gameRank");
   const retry = searchParams.get("retry");
 
-  const gameStyleRaw = searchParams.get("gameStyleResponseList");
+  const gameStyleRaw = searchParams.get("gameStyleIdList");
   const user: User = {
     memberId: parseInt(searchParams.get("memberId") || "0", 10),
     gameName: searchParams.get("gameName") || "",
@@ -81,32 +82,59 @@ const Progress = () => {
     wantP: (searchParams.get("wantP") as Position) || "ANY",
     mike: (searchParams.get("mike") as Mike) || "AVAILABLE",
     gameStyleList: gameStyleRaw
-      ? (JSON.parse(gameStyleRaw) as GameStyleList[]).map(
-          (style) => style.gameStyleName
-        )
+      ? (JSON.parse(gameStyleRaw) as number[]).map((id) => {
+          const found = GAME_STYLE.find((style) => style.gameStyleId === id);
+          return found ? found.gameStyleName : "";
+        })
       : [],
   };
 
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  // 파라미터에서 tierCounts 가져오기
+  const tierCountsRaw = searchParams.get("tierCounts");
 
-  const [tierCounts, setTierCounts] = useState<Record<string, number>>({}); // 티어별 인원 수
+  // 안전하게 파싱 tierCount + userCount
+  const parsedTierCounts = (() => {
+    try {
+      if (!tierCountsRaw) return {};
+      const parsed = JSON.parse(tierCountsRaw);
+      if (parsed && parsed.tierCount && parsed.userCount !== undefined) {
+        return {
+          ...parsed.tierCount,
+          total: parsed.userCount,
+        };
+      }
+      return {};
+    } catch (e) {
+      console.error("tierCounts 파싱 실패:", e);
+      return {};
+    }
+  })();
+
+  // 초기값으로 바로 사용
+  const [tierCounts, setTierCounts] =
+    useState<Record<string, number>>(parsedTierCounts); // 티어별 인원 수
+
   const [currentMessage, setCurrentMessage] = useState<string>("");
   const [textVisible, setTextVisible] = useState<boolean>(true);
 
+  const tierCountsRef = useRef(tierCountsRaw);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
   const thresholdRef = useRef(51.5);
 
   // const [showReloadModal, setShowReloadModal] = useState(false); // 새로고침 모달 상태
 
   useEffect(() => {
+    if (!socket) return;
+
     const handleMatchingCount = (data: any) => {
-      setTierCounts({ ...data.tierCount, total: data.userCount });
+      setTierCounts({ ...data.data.tierCount, total: data.data.userCount });
     };
 
-    socket?.on("matching-count", handleMatchingCount);
+    socket.on("matching-count", handleMatchingCount);
     return () => {
       socket?.off("matching-count", handleMatchingCount);
     };
-  }, []);
+  }, [socket]);
 
   const showMessage = () => {
     setTextVisible(false);
@@ -128,6 +156,10 @@ const Progress = () => {
 
       const tierUserCount = tierCounts[tierKey] ?? 0;
       const totalUserCount = tierCounts["total"] ?? 0;
+
+      console.log("tierCounts", tierCounts);
+      console.log("tierUserCount", tierUserCount);
+      console.log("totalUserCount", totalUserCount);
 
       if (messagesWithTierN.includes(randomMessage)) {
         setCurrentMessage(

--- a/src/app/matching/progress/page.tsx
+++ b/src/app/matching/progress/page.tsx
@@ -15,7 +15,6 @@ import {
   messagesWithTierN,
   messagesWithTotalN,
 } from "@/constants/messages";
-// import { getSystemMsg } from "@/api/socket";
 import { getBoardList } from "@/api/board/board";
 import { setOpenPostingModal } from "@/redux/slices/modalSlice";
 import { useDispatch } from "react-redux";
@@ -211,14 +210,13 @@ const Progress = () => {
       console.log("매칭 상대 발견(receiver):", data); // senderMatchingInfo, receiverMatchingUuid
       clearTimers();
       socket?.emit("matching-found-success", {
-        // senderMemberId: data.data.memberId,
-        // gameMode: data.data.gameMode,
-        senderMatchingUuid: data.data.receiverMatchingUuid,
-        gameMode: data.data.senderMatchingInfo.gameMode,
+        // senderMatchingUuid: data.data.receiverMatchingUuid,
+        senderMatchingUuid: data.data.senderMatchingInfo.matchingUuid,
       });
       router.push(
         `/matching/complete?role=receiver&opponent=true&type=${type}&rank=${rank}&user=${encodeURIComponent(
-          JSON.stringify(data.data)
+          JSON.stringify(data.data.senderMatchingInfo)
+        )}&uuid=${encodeURIComponent(data.data.senderMatchingInfo.matchingUuid)}
         )}`
       );
     });
@@ -440,20 +438,6 @@ const Header = styled.div`
   align-items: center;
   white-space: nowrap;
 `;
-
-// const Time = styled.div`
-//   color: ${theme.colors.gray700};
-//   ${(props) => props.theme.fonts.light32}
-//   margin-bottom: 32px;
-// `;
-
-// const Span = styled.span`
-//   color: ${theme.colors.violet600};
-//   ${(props) => props.theme.fonts.bold32}
-//   @media (max-width: 700px) {
-//     ${(props) => props.theme.fonts.bold32}
-//   }
-// `;
 
 const Main = styled.main`
   display: grid;


### PR DESCRIPTION
## 연관 이슈

close #268

<br/>

## 📁 작업 내용

- 매칭 중 동시 접속 인원 반영 오류 수정
> 문제상황: matching-started 직후에 matching-count가 들어오기에 해당 이벤트가 매칭중 페이지가 아닌 프로필 설정 페이지에서 들어옴. 따라서 tierCount가 초기화되지 않는 문제 발생.

> 해결: matching-started 후 matching-count 이벤트가 들어왔을 때 페이지 이동을 시켜 화면상 매칭중 단계로 넘어가게 함. 이때 응답값으로 받은 tierCount 정보를 매칭중 페이지의 params로 이동시켜 초기화 성공. 또한, useState 대신, useRef를 사용하여 matching-count 이벤트가 들어올 때마다 tierCount의 상태를 즉각적으로 업데이트한다!

- `matching-started`에서의 gameStyleId 응답값 변경(number[]) 반영
<br/>


