### PR TITLE
[Feat] 게시판 목록 모바일 무한스크롤 구현

### DIFF
--- a/src/api/board/board.ts
+++ b/src/api/board/board.ts
@@ -7,6 +7,7 @@ import {
   BoardPullUpResponse,
   GetBoardListResponse,
   GetMyBoardListResponse,
+  GetBoardListCursorResponse,
   MemberPostBoardResponse,
   NotMemberBoardResponse,
   PostsResponse,
@@ -20,8 +21,16 @@ interface ListInterface {
   page: number;
   gameMode: GameMode | null;
   tier: string | null;
-  mainP: Position
+  mainP: Position;
   mike: string | boolean | null;
+}
+
+interface CursorListInterface {
+  cursor: string | null;
+  cursorId: number | null;
+  gameMode: GameMode | null;
+  tier: string | null;
+  position1: Position;
 }
 
 /* 글쓰기 */
@@ -29,17 +38,17 @@ export const postBoard = async (params: PostReq): Promise<PostsResponse> => {
   try {
     const response = await AuthAxios.post("/api/v2/posts", params);
     return response.data;
-} catch (error: any) {
-      console.error("글쓰기 실패:", error);
-      if (error.response.data.code === "BOARD_412") {
-        notify({
-          text: BOARD.MESSAGE.COOLTIME,
-          icon: "🚫",
-          type: "error",
-        });
-      }
-      throw error;
+  } catch (error: any) {
+    console.error("글쓰기 실패:", error);
+    if (error.response.data.code === "BOARD_412") {
+      notify({
+        text: BOARD.MESSAGE.COOLTIME,
+        icon: "🚫",
+        type: "error",
+      });
     }
+    throw error;
+  }
 };
 
 /* 게시글 목록 조회 */
@@ -51,6 +60,21 @@ export const getBoardList = async (
     return response.data;
   } catch (error) {
     console.error("게시판 목록 불러오기 실패:", error);
+    throw error;
+  }
+};
+
+/* 커서 기반 게시글 목록 조회 */
+export const getBoardListCursor = async (
+  params: CursorListInterface
+): Promise<GetBoardListCursorResponse> => {
+  try {
+    const response = await AuthAxios.get("/api/v2/posts/cursor", {
+      params,
+    });
+    return response.data;
+  } catch (error) {
+    console.error("커서 기반 게시판 목록 불러오기 실패:", error);
     throw error;
   }
 };
@@ -83,16 +107,15 @@ export const getNonMemberPost = async (
 
 /* 게시글 끌올 */
 export const pullUpPost = async (
-  postId: number,
+  postId: number
 ): Promise<BoardPullUpResponse> => {
   try {
-    const response = await AuthAxios.post(
-      `/api/v2/posts/${postId}/bump`
-    );
+    const response = await AuthAxios.post(`/api/v2/posts/${postId}/bump`);
     return response.data;
-  } catch (error:any) {
+  } catch (error: any) {
     console.error("게시글 끌올 실패:", error);
-    if (error.response.data.code === "BOARD_411") { // 끌올 1시간 제한
+    if (error.response.data.code === "BOARD_411") {
+      // 끌올 1시간 제한
       notify({
         text: error.response.data.message,
         icon: "🚫",
@@ -131,7 +154,9 @@ export const deletePost = async (
 };
 
 /* 내가 쓴 글 목록 조회 */
-export const getMyPost = async (page: number): Promise<GetMyBoardListResponse> => {
+export const getMyPost = async (
+  page: number
+): Promise<GetMyBoardListResponse> => {
   const endpoint = `/api/v2/posts/my?page=${page}`;
   try {
     const response = await AuthAxios.get(endpoint);

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -18,7 +18,12 @@ import {
   setOpenModal,
   setOpenPostingModal,
 } from "@/redux/slices/modalSlice";
-import { getBoardList, getMyPost, pullUpPost } from "@/api/board/board";
+import {
+  getBoardList,
+  getBoardListCursor,
+  getMyPost,
+  pullUpPost,
+} from "@/api/board/board";
 import { BoardListDetail } from "@/interface/board";
 import Alert from "@/components/common/Alert";
 import { clearCurrentPost, setPostStatus } from "@/redux/slices/postSlice";
@@ -71,6 +76,9 @@ const BoardPage = () => {
   );
   const isPostStatus = useSelector((state: RootState) => state.post.postStatus);
   const isUser = useSelector((state: RootState) => state.user);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasNext, setHasNext] = useState<boolean>(true);
+  const sentinelRef = useRef(null);
 
   /* redux 필터 상태 가져오기 */
   const boardFilters = useSelector((state: RootState) => state.board);
@@ -132,7 +140,6 @@ const BoardPage = () => {
     document.addEventListener("mousedown", handleGameModeDropdownClickOutside);
     document.addEventListener("mousedown", handleTierDropdownClickOutside);
     document.addEventListener("mousedown", handleMicDropdownClickOutside);
-    document.addEventListener("scroll", handleScroll);
 
     return () => {
       document.removeEventListener(
@@ -203,9 +210,90 @@ const BoardPage = () => {
     }
   };
 
+  /* 게시글 목록 조회 init (커서 기반) */
+  const getInitialListByCursor = async () => {
+    if (isLoading) return;
+    const params = {
+      cursor: null,
+      cursorId: null,
+      gameMode:
+        boardFilters.gameMode && boardFilters.gameMode !== null
+          ? boardFilters.gameMode
+          : selectedGameMode,
+      tier:
+        boardFilters.tier && boardFilters.tier !== null
+          ? boardFilters.tier
+          : selectedTier,
+      position1: isPosition,
+    };
+
+    setIsLoading(true);
+    try {
+      const data = await getBoardListCursor(params);
+      if (data.status === 200) {
+        if (data.data.boards) {
+          setBoardList(data.data.boards);
+        }
+        setCursor(data.data.nextCursor);
+        setHasNext(data.data.hasNext);
+      } else {
+        console.error(data.message);
+      }
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  /* 게시글 목록 조회 (커서 기반) */
+  const getListByCursor = async (cursor: string | null) => {
+    if (isLoading || !hasNext) return;
+    const params = {
+      cursor,
+      cursorId: null,
+      gameMode:
+        boardFilters.gameMode && boardFilters.gameMode !== null
+          ? boardFilters.gameMode
+          : selectedGameMode,
+      tier:
+        boardFilters.tier && boardFilters.tier !== null
+          ? boardFilters.tier
+          : selectedTier,
+      position1: isPosition,
+    };
+
+    setIsLoading(true);
+    try {
+      const data = await getBoardListCursor(params);
+      if (data.status === 200) {
+        if (data.data.boards) {
+          setBoardList((prevBoardList) => [
+            ...prevBoardList,
+            ...data.data.boards,
+          ]);
+        }
+        setCursor(data.data.nextCursor);
+        setHasNext(data.data.hasNext);
+      } else {
+        console.error(data.message);
+      }
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   useEffect(() => {
-    getList();
+    if (isMobile === undefined) return;
     console.log("boardRefresh", boardRefresh);
+
+    if (isMobile) {
+      getInitialListByCursor();
+    } else {
+      getList();
+    }
   }, [
     currentPage,
     selectedGameMode,
@@ -214,7 +302,34 @@ const BoardPage = () => {
     selectedMic,
     isPostStatus,
     boardRefresh,
+    isMobile,
   ]);
+
+  /* mobile 무한스크롤 페이지네이션 */
+  useEffect(() => {
+    if (!isMobile || !cursor) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting && hasNext && !isLoading) {
+            getListByCursor(cursor);
+          }
+        });
+      },
+      {
+        rootMargin: "100px", // 미리 로드
+      }
+    );
+
+    if (sentinelRef.current) {
+      observer.observe(sentinelRef.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [cursor, isMobile, hasNext, isLoading]);
 
   /* 페이지네이션 이전 클릭 */
   const handlePrevPage = () => {
@@ -275,15 +390,6 @@ const BoardPage = () => {
       icon: "👌🏼",
       type: "success",
     });
-  };
-
-  /* TODO: 모바일 무한스크롤 - 스크롤이 끝에 도달하면 다음 페이지 가져오기 */
-  const handleScroll = () => {
-    // const scrollBottom =
-    //   window.innerHeight + window.scrollY >= document.body.offsetHeight - 100;
-    // if (scrollBottom && !isLoading) {
-    //   setCurrentPage((prev) => prev + 1);
-    // }
   };
 
   return (
@@ -500,6 +606,8 @@ const BoardPage = () => {
                 <Main>
                   <PostList content={boardList}></PostList>
                 </Main>
+                <div ref={sentinelRef}></div>{" "}
+                {/* IntersectionObserver 를 위한 감지용 element */}
               </>
             )}
           </BoardContent>

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -148,7 +148,6 @@ const BoardPage = () => {
       );
       document.removeEventListener("mousedown", handleTierDropdownClickOutside);
       document.removeEventListener("mousedown", handleMicDropdownClickOutside);
-      document.removeEventListener("scroll", handleScroll);
     };
   }, []);
 

--- a/src/components/match/WaitingBox.tsx
+++ b/src/components/match/WaitingBox.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 import styled from "styled-components";
 
 interface WaitingBoxProps {
-  isMobile: boolean;
+  isMobile: boolean | undefined;
   textVisible: boolean;
   currentMessage: string;
   timeLeft: number;

--- a/src/components/profile/UpdateProfileImage.tsx
+++ b/src/components/profile/UpdateProfileImage.tsx
@@ -26,7 +26,10 @@ const UpdateProfileImage = (props: FileInputProps) => {
     selectedImageIndex,
   } = props;
 
-  const getSizeByContext = (type: ProfileType, isMobile: boolean): SizeType => {
+  const getSizeByContext = (
+    type: ProfileType,
+    isMobile: boolean | undefined
+  ): SizeType => {
     if (type === "matching" && !isMobile) return "large";
     if (type === "mypage" && !isMobile) return "medium";
     if (type === "board" && !isMobile) return "semiMedium";

--- a/src/hooks/useMediaQueries.ts
+++ b/src/hooks/useMediaQueries.ts
@@ -5,7 +5,7 @@ export interface UseMediaQueriesProps {
 }
 
 const useMediaQueries = ({ breakpoint }: UseMediaQueriesProps) => {
-  const [matches, setMatches] = useState(false);
+  const [matches, setMatches] = useState<boolean | undefined>(undefined);
 
   useEffect(() => {
     // SSR 환경에서는 window가 없으므로, useEffect 내부에서만 사용해야 안전함

--- a/src/types/api/board/board.d.ts
+++ b/src/types/api/board/board.d.ts
@@ -56,6 +56,12 @@ interface BoardListStructure {
   totalCount: number;
 }
 
+interface BoardListCursorStructure {
+  cursorId: number;
+  hasNext: boolean;
+  nextCursor: string;
+}
+
 interface MyBoardListStructure {
   totalPage: number;
   totalCount: number;
@@ -68,6 +74,10 @@ export interface PostsData extends BasePlayerInfo, GameInfo, BaseBoardInfo {
 }
 
 export interface GetBoardListData extends BoardListStructure {
+  boards: Array<BoardDetail>;
+}
+
+export interface GetBoardListCursorData extends BoardListCursorStructure {
   boards: Array<BoardDetail>;
 }
 
@@ -147,3 +157,4 @@ export type NotMemberBoardResponse = ApiResponse<NotMemberBoardData>;
 export type MemberPostBoardResponse = ApiResponse<MemberPostBoardData>;
 export type GetBoardListResponse = ApiResponse<GetBoardListData>;
 export type GetMyBoardListResponse = ApiResponse<GetMyBoardListData>;
+export type GetBoardListCursorResponse = ApiResponse<GetBoardListCursorData>;


### PR DESCRIPTION
## 연관 이슈

close #263 

<br/>

## 📁 작업 내용

모바일에서의 게시판 목록 무한스크롤을 구현하였습니다. 
<br/>

## 🖥 구현 결과 (선택)

![화면 기록 2025-06-27 오후 4 42 05](https://github.com/user-attachments/assets/20444bea-2e54-4a7a-ad95-0cc43e273c41)


<br/>

## ✔ 리뷰 요구사항

없습니다. 
<br/>

## 📁 기타 사항
- useMediaQueries 훅의 기본값을 undefined로 지정해뒀습니다. PC인지 Mobile인지 여부를 리턴해야하는데 기본값으로 초기에 false를 반환하여 PC 버전의 API를 호출하는 상황이 있어 적용하였습니다. 


<br/>
