### PR TITLE
[Fix] 모달 및 팝업 오픈 시 스크롤 막는 작업(게시판, Alert, ConfirmModal컴포넌트)

### DIFF
--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -7,7 +7,6 @@ import styled from "styled-components";
 
 import { getBoardList, getBoardListCursor, getMyPost, pullUpPost } from "@/api";
 import {
-  Alert,
   Button,
   ConfirmModal,
   Dropdown,
@@ -23,6 +22,7 @@ import { notify, useMediaQueryContext } from "@/hooks";
 import { resetBoardFilters, setRefresh } from "@/redux/slices/boardSlice";
 import {
   setClosePostingModal,
+  setOpenAlertModal,
   setOpenModal,
   setOpenPostingModal,
 } from "@/redux/slices/modalSlice";
@@ -39,6 +39,8 @@ const BUTTONS_PER_PAGE = 5;
 
 const BoardPage = () => {
   const dispatch = useDispatch();
+  const { isMobile } = useMediaQueryContext();
+
   const [boardList, setBoardList] = useState<BoardListDetail[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPage, setTotalPage] = useState(0);
@@ -52,8 +54,12 @@ const BoardPage = () => {
   );
   const [selectedTier, setSelectedTier] = useState<string | null>(null);
   const [selectedMic, setSelectedMic] = useState<Mike | null>(null);
-  const [showAlert, setShowAlert] = useState(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isPullUpConfirmOpen, setIsPullUpConfirmOpen] = useState(false);
+  const [myRecentPost, setMyRecentPost] = useState<number | null>(null);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasNext, setHasNext] = useState<boolean>(true);
+  const [isRotating, setIsRotating] = useState(false);
 
   // 게시판 글 새로고침
   const boardRefresh = useSelector((state: RootState) => state.board.refresh);
@@ -61,21 +67,13 @@ const BoardPage = () => {
   const gameModeRef = useRef<HTMLDivElement>(null);
   const tierRef = useRef<HTMLDivElement>(null);
   const micRef = useRef<HTMLDivElement>(null);
-  const [isRotating, setIsRotating] = useState(false);
-  const { isMobile } = useMediaQueryContext();
-
-  const [isPullUpConfirmOpen, setIsPullUpConfirmOpen] = useState(false);
-  const [myRecentPost, setMyRecentPost] = useState<number | null>(null);
+  const sentinelRef = useRef(null); // IntersectionObserver 를 위한 감지용 element
 
   const isPostingModal = useSelector(
     (state: RootState) => state.modal.postingModal
   );
   const isPostStatus = useSelector((state: RootState) => state.post.postStatus);
   const isUser = useSelector((state: RootState) => state.user);
-  const [cursor, setCursor] = useState<string | null>(null);
-  const [hasNext, setHasNext] = useState<boolean>(true);
-  const sentinelRef = useRef(null);
-
   /* redux 필터 상태 가져오기 */
   const boardFilters = useSelector((state: RootState) => state.board);
 
@@ -156,7 +154,16 @@ const BoardPage = () => {
   /* 글쓰기 모달 오픈 */
   const handlePostingOpen = () => {
     if (!isUser.gameName) {
-      return setShowAlert(true);
+      return dispatch(
+        setOpenAlertModal({
+          icon: "exclamation",
+          width: 68,
+          height: 58,
+          content: "로그인이 필요한 서비스입니다.",
+          alt: "로그인 필요",
+          buttonText: "확인",
+        })
+      );
     }
 
     dispatch(setOpenPostingModal());
@@ -401,17 +408,6 @@ const BoardPage = () => {
 
   return (
     <>
-      {showAlert && (
-        <Alert
-          icon="exclamation"
-          width={68}
-          height={58}
-          content="로그인이 필요한 서비스입니다."
-          alt="로그인 필요"
-          onClose={() => setShowAlert(false)}
-          buttonText="확인"
-        />
-      )}
       {isPostingModal && (
         <PostBoard
           onClose={handlePostingClose}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,7 +10,7 @@ import { persistStore } from "redux-persist";
 import { PersistGate } from "redux-persist/integration/react";
 import styled, { ThemeProvider } from "styled-components";
 
-import { Footer, Header, SocketConnection } from "@/components";
+import { Footer, Header, ModalContainer, SocketConnection } from "@/components";
 import ko from "@/constants/ko.json";
 import { STORAGE_KEY } from "@/constants/storage";
 import { MediaQueryProvider } from "@/contexts/MediaQueryContext";
@@ -143,6 +143,7 @@ export default function RootLayout({
                       <SocketConnection
                         key={isLoggedIn ? "loggedIn" : "loggedOut"}
                       />
+                      <ModalContainer />
                       <Container>
                         <Main>
                           {isHeaderFooterShow && <Header />}

--- a/src/app/match/page.tsx
+++ b/src/app/match/page.tsx
@@ -1,39 +1,43 @@
 "use client";
 
 import { useState } from "react";
+import { useDispatch } from "react-redux";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 
-import { Alert, GraphicBox, HeaderTitle } from "@/components";
+import { GraphicBox, HeaderTitle } from "@/components";
 import { MATCH_TYPE_PAGE_DATA, MO_MATCH_TYPE_PAGE_DATA } from "@/constants";
 import { useMediaQueryContext } from "@/hooks";
+import { setOpenAlertModal } from "@/redux/slices/modalSlice";
 import { theme } from "@/styles/theme";
 import { getAccessToken } from "@/utils";
 
 import ChevronRight from "../../../public/assets/icons/chevron_right.svg";
 
 const MatchTypePage = () => {
+  const dispatch = useDispatch();
   const { isMobile } = useMediaQueryContext();
   const router = useRouter();
 
   const accesssToken = getAccessToken(); // 로그인 유무 결정
-  const [showAlert, setShowAlert] = useState(false);
   const [hoveredBox, setHoveredBox] = useState<number | null>(null);
+
+  const showLoginAlert = () => {
+    dispatch(
+      setOpenAlertModal({
+        icon: "exclamation",
+        width: 68,
+        height: 58,
+        content: "로그인이 필요한 서비스입니다.",
+        alt: "경고",
+        buttonText: "확인",
+      })
+    );
+  };
 
   return (
     <Wrapper>
-      {showAlert && (
-        <Alert
-          icon="exclamation"
-          width={68}
-          height={58}
-          content="로그인이 필요한 서비스입니다."
-          alt="경고"
-          onClose={() => setShowAlert(false)}
-          buttonText="확인"
-        />
-      )}
       <MatchContent>
         <HeaderTitle title="매칭 종류 선택" />
         <Main>
@@ -62,7 +66,7 @@ const MatchTypePage = () => {
                                   ? `${box.pathname}?type=${box.type}`
                                   : box.pathname
                               )
-                          : () => setShowAlert(true)
+                          : () => showLoginAlert()
                       }
                     >
                       선택
@@ -94,9 +98,7 @@ const MatchTypePage = () => {
                     } // Hover 시 배경 변경
                     onMouseEnter={() => setHoveredBox(box.id)}
                     onMouseLeave={() => setHoveredBox(null)}
-                    onClick={
-                      accesssToken ? undefined : () => setShowAlert(true)
-                    }
+                    onClick={accesssToken ? undefined : () => showLoginAlert()}
                   >
                     <GraphicBoxTitle>
                       <GraphicBoxTitleMain>

--- a/src/components/alert/AlertWindow.tsx
+++ b/src/components/alert/AlertWindow.tsx
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import { getPopupNotification, patchReadNotification } from "@/api";
 import { useMediaQueryContext } from "@/hooks";
 import { theme } from "@/styles/theme";
+import { lockBodyScroll, unlockBodyScroll } from "@/utils";
 
 import AlertBox from "../mypage/notification/AlertBox";
 
@@ -105,11 +106,11 @@ const AlertWindow = (props: AlertWindowProps) => {
 
   useEffect(() => {
     if (!isMobile) return;
-    document.body.style.overflow = "hidden";
+    lockBodyScroll();
 
     return () => {
       if (modalRoot && modalRoot.children.length === 0) {
-        document.body.style.overflow = "unset";
+        unlockBodyScroll();
       }
     };
   }, [modalRoot, isMobile]);

--- a/src/components/alert/AlertWindow.tsx
+++ b/src/components/alert/AlertWindow.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
@@ -23,7 +24,7 @@ const AlertWindow = (props: AlertWindowProps) => {
   const { countFunc, onClose, alertButtonRef } = props;
 
   const alertWindowRef = useRef<HTMLDivElement>(null);
-
+  const modalRoot = document.getElementById("modal-root") as HTMLElement;
   const [notiList, setNotiList] = useState<Notification[]>([]);
   const [cursor, setCursor] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -102,6 +103,17 @@ const AlertWindow = (props: AlertWindowProps) => {
     []
   );
 
+  useEffect(() => {
+    if (!isMobile) return;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      if (modalRoot && modalRoot.children.length === 0) {
+        document.body.style.overflow = "unset";
+      }
+    };
+  }, [modalRoot, isMobile]);
+
   /* 알림 읽음으로 상태 변경 */
   const handleClickAlert = async (
     notificationId: number,
@@ -131,7 +143,7 @@ const AlertWindow = (props: AlertWindowProps) => {
     }
   };
 
-  return (
+  return createPortal(
     <>
       <Overlay>
         <Wrapper ref={alertWindowRef}>
@@ -188,7 +200,8 @@ const AlertWindow = (props: AlertWindowProps) => {
           </Background>
         </Wrapper>
       </Overlay>
-    </>
+    </>,
+    modalRoot
   );
 };
 

--- a/src/components/board/PostList.tsx
+++ b/src/components/board/PostList.tsx
@@ -3,9 +3,10 @@ import { useDispatch, useSelector } from "react-redux";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 
-import { Alert, Layout, ReadBoard, ReportModal } from "@/components";
+import { Layout, ReadBoard, ReportModal } from "@/components";
 import {
   setCloseReadingModal,
+  setOpenAlertModal,
   setOpenReadingModal,
 } from "@/redux/slices/modalSlice";
 import { theme } from "@/styles/theme";
@@ -13,7 +14,6 @@ import { theme } from "@/styles/theme";
 import { PostItem } from "../common";
 
 import type { RootState } from "@/redux/store";
-import type { AlertProps } from "@/types";
 import type { BoardListDetail } from "@/types/api";
 
 interface PostListProps {
@@ -25,8 +25,6 @@ const PostList = ({ content }: PostListProps) => {
   const router = useRouter();
 
   const [isBoardId, setIsBoardId] = useState(0);
-  const [showAlert, setShowAlert] = useState(false);
-  const [alertContent, setAlertContent] = useState("");
 
   const isChatRoomOpen = useSelector(
     (state: RootState) => state.chat.isChatRoomOpen
@@ -36,15 +34,6 @@ const PostList = ({ content }: PostListProps) => {
   );
   const isModalType = useSelector((state: RootState) => state.modal.modalType);
 
-  const [alertProps, setAlertProps] = useState<AlertProps>({
-    icon: "",
-    width: 0,
-    height: 0,
-    content: "",
-    alt: "",
-    onClose: () => {},
-    buttonText: "",
-  });
 
   useEffect(() => {
     return () => {
@@ -57,8 +46,16 @@ const PostList = ({ content }: PostListProps) => {
     const exists = content.some((board) => board.boardId === boardId);
 
     if (!exists) {
-      setAlertContent("해당 글은 삭제된 글입니다.");
-      return setShowAlert(true);
+      return dispatch(
+        setOpenAlertModal({
+          icon: "trash",
+          width: 45,
+          height: 50,
+          content: "해당 글은 삭제된 글입니다.",
+          alt: "해당 글은 삭제된 글입니다.",
+          buttonText: "확인",
+        })
+      );
     }
 
     dispatch(setOpenReadingModal());
@@ -73,21 +70,6 @@ const PostList = ({ content }: PostListProps) => {
 
   return (
     <>
-      {showAlert && (
-        <Alert
-          icon={
-            alertContent === "로그인이 필요한 서비스입니다."
-              ? "exclamation"
-              : "trash"
-          }
-          width={45}
-          height={50}
-          content={alertContent}
-          alt={alertContent}
-          onClose={() => setShowAlert(false)}
-          buttonText="확인"
-        />
-      )}
       {isReadingModal && !isChatRoomOpen && <ReadBoard postId={isBoardId} />}
 
       {isChatRoomOpen && <Layout />}

--- a/src/components/board/PostList.tsx
+++ b/src/components/board/PostList.tsx
@@ -34,7 +34,6 @@ const PostList = ({ content }: PostListProps) => {
   );
   const isModalType = useSelector((state: RootState) => state.modal.modalType);
 
-
   useEffect(() => {
     return () => {
       dispatch(setCloseReadingModal());

--- a/src/components/board/Table.tsx
+++ b/src/components/board/Table.tsx
@@ -279,8 +279,8 @@ const Table = (props: TableProps) => {
   const handleEdit = async () => {
     setIsMoreBoxOpen((prevState) => !prevState);
     if (isBoardId) {
-      await dispatch(setOpenPostingModal());
       await dispatch(setCloseReadingModal());
+      await dispatch(setOpenPostingModal());
       dispatch(setPostStatus(""));
     }
   };

--- a/src/components/board/Table.tsx
+++ b/src/components/board/Table.tsx
@@ -30,6 +30,7 @@ import { setRefresh } from "@/redux/slices/boardSlice";
 import {
   setCloseModal,
   setCloseReadingModal,
+  setOpenAlertModal,
   setOpenModal,
   setOpenPostingModal,
   setOpenReadingModal,
@@ -70,8 +71,6 @@ const Table = (props: TableProps) => {
 
   const [isBoardId, setIsBoardId] = useState(0);
   const [isPost, setIsPost] = useState<MemberPost>();
-  const [showAlert, setShowAlert] = useState(false);
-  const [alertContent, setAlertContent] = useState("");
   const isChatRoomOpen = useSelector(
     (state: RootState) => state.chat.isChatRoomOpen
   );
@@ -89,15 +88,6 @@ const Table = (props: TableProps) => {
   const [isBlockBoxOpen, setIsBlockBoxOpen] = useState(false);
   const [isBlockConfirmOpen, setIsBlockConfrimOpen] = useState(false);
   const [isPullUpConfirmOpen, setIsPullUpConfirmOpen] = useState(false);
-  const [alertProps, setAlertProps] = useState<AlertProps>({
-    icon: "",
-    width: 0,
-    height: 0,
-    content: "",
-    alt: "",
-    onClose: () => {},
-    buttonText: "",
-  });
 
   /* 로그아웃 시, 비회원 접근 시 알럿 props 설정 함수 */
   const logoutMessage = "로그아웃 되었습니다. 다시 로그인 해주세요.";
@@ -109,8 +99,16 @@ const Table = (props: TableProps) => {
     const exists = content.some((board) => board.boardId === boardId);
 
     if (!exists) {
-      setAlertContent("해당 글은 삭제된 글입니다.");
-      return setShowAlert(true);
+      return dispatch(
+        setOpenAlertModal({
+          icon: "trash",
+          width: 45,
+          height: 50,
+          content: deletedMessage,
+          alt: deletedMessage,
+          buttonText: "확인",
+        })
+      );
     }
 
     dispatch(setOpenReadingModal());
@@ -123,16 +121,17 @@ const Table = (props: TableProps) => {
     handleAlertClose: () => void,
     btnText: string
   ) => {
-    setAlertProps({
-      icon: icon,
-      width: 68,
-      height: 58,
-      content: content,
-      alt: "경고",
-      onClose: handleAlertClose,
-      buttonText: btnText,
-    });
-    setShowAlert(true);
+    dispatch(
+      setOpenAlertModal({
+        icon,
+        width: 68,
+        height: 58,
+        content,
+        alt: "경고",
+        buttonText: btnText,
+        onClose: handleAlertClose,
+      })
+    );
   };
 
   useEffect(() => {
@@ -378,22 +377,6 @@ const Table = (props: TableProps) => {
 
   return (
     <>
-      {showAlert && (
-        <Alert
-          icon={
-            alertContent === "로그인이 필요한 서비스입니다."
-              ? "exclamation"
-              : "trash"
-          }
-          width={45}
-          height={50}
-          content={alertContent}
-          alt={alertContent}
-          onClose={() => setShowAlert(false)}
-          buttonText="확인"
-        />
-      )}
-
       {isReadingModal && !isChatRoomOpen && <ReadBoard postId={isBoardId} />}
 
       {isChatRoomOpen && <Layout />}

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -963,6 +963,10 @@ const Text = styled.div`
   color: ${theme.colors.gray600};
   ${(props) => props.theme.fonts.regular20};
   margin: 28px 0;
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    margin: 28px 0 0 0;
+    ${(props) => props.theme.fonts.medium14};
+  }
 `;
 
 const SmallText = styled.div`

--- a/src/components/chat/Layout.tsx
+++ b/src/components/chat/Layout.tsx
@@ -561,7 +561,8 @@ const Layout = () => {
         >
           <div>
             <Text>
-              차단한 상대에게는 메시지를 받을 수 없으며 <br />매칭이 이루어지지 않습니다. 차단하시겠습니까?
+              차단한 상대에게는 메시지를 받을 수 없으며 <br />
+              매칭이 이루어지지 않습니다. 차단하시겠습니까?
             </Text>
             <SmallText>{` 차단 해제는 마이페이지에서 가능합니다.`}</SmallText>
           </div>
@@ -882,7 +883,6 @@ const SmallText = styled.div`
   color: ${theme.colors.gray200};
   ${(props) => props.theme.fonts.regular14};
   margin-top: 13px;
-  
 `;
 
 const MsgConfirm = styled(Text)`

--- a/src/components/chat/Layout.tsx
+++ b/src/components/chat/Layout.tsx
@@ -561,7 +561,7 @@ const Layout = () => {
         >
           <div>
             <Text>
-              {`차단한 상대에게는 메시지를 받을 수 없으며\n매칭이 이루어지지 않습니다. 차단하시겠습니까?`}
+              차단한 상대에게는 메시지를 받을 수 없으며 <br />매칭이 이루어지지 않습니다. 차단하시겠습니까?
             </Text>
             <SmallText>{` 차단 해제는 마이페이지에서 가능합니다.`}</SmallText>
           </div>
@@ -871,6 +871,10 @@ const Text = styled.div`
   color: ${theme.colors.gray600};
   ${(props) => props.theme.fonts.regular20};
   margin: 28px 0;
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    margin: 28px 0 0 0;
+    ${(props) => props.theme.fonts.medium14};
+  }
 `;
 
 const SmallText = styled.div`
@@ -878,9 +882,14 @@ const SmallText = styled.div`
   color: ${theme.colors.gray200};
   ${(props) => props.theme.fonts.regular14};
   margin-top: 13px;
+  
 `;
 
 const MsgConfirm = styled(Text)`
   ${(props) => props.theme.fonts.regular25};
   margin: 80px 0;
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    ${(props) => props.theme.fonts.medium14};
+    margin: 32px 0;
+  }
 `;

--- a/src/components/chat/Layout.tsx
+++ b/src/components/chat/Layout.tsx
@@ -29,7 +29,7 @@ import {
 import { setCloseModal, setOpenModal } from "@/redux/slices/modalSlice";
 import { socket } from "@/socket";
 import { theme } from "@/styles/theme";
-import { getAccessToken } from "@/utils";
+import { getAccessToken, lockBodyScroll, unlockBodyScroll } from "@/utils";
 
 import { Button, Checkbox, ConfirmModal, FormModal, Input } from "../common";
 import { ChatFriendList, ChatLayout, ChatRoomList, SearchBar, Tabs } from "./";
@@ -151,11 +151,11 @@ const Layout = () => {
 
   useEffect(() => {
     if (!isMobile) return;
-    document.body.style.overflow = "hidden";
+    lockBodyScroll();
 
     return () => {
       if (modalRoot && modalRoot.children.length === 0) {
-        document.body.style.overflow = "unset";
+        unlockBodyScroll();
       }
     };
   }, [modalRoot, isMobile]);

--- a/src/components/chat/Layout.tsx
+++ b/src/components/chat/Layout.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { useDispatch, useSelector } from "react-redux";
 import Image from "next/image";
 import styled from "styled-components";
@@ -43,8 +44,6 @@ const Layout = () => {
   /* 채팅창 위치 관련 상태 */
   const position = useSelector((state: RootState) => state.chatPosition);
   const activeTab = useSelector((state: RootState) => state.chat.activeTab);
-  // const [isDragging, setIsDragging] = useState(false);
-  // const [offset, setOffset] = useState({ x: 0, y: 0 });
 
   const [friends, setFriends] = useState<FriendList[]>([]);
   const [favoriteFriends, setFavoriteFriends] = useState<FriendList[]>([]);
@@ -74,6 +73,7 @@ const Layout = () => {
     (state: RootState) => state.chat.isChatRoomUuid
   );
   const isModalType = useSelector((state: RootState) => state.modal.modalType);
+  const modalRoot = document.getElementById("modal-root") as HTMLElement;
 
   /* 채팅창 위치 관련 함수 */
   // 경계 제한 로직
@@ -142,17 +142,23 @@ const Layout = () => {
     setFavoriteFriends(likedFriends);
   }, [friends]);
 
-  useEffect(() => {
-    const likedFriends = friends.filter((friend) => friend.liked);
-    setFavoriteFriends(likedFriends);
-  }, [friends]);
-
   /* 검색 중이 아닐 때만 전체 목록을 가져오기. */
   useEffect(() => {
     if (!isSearching) {
       handleFetchFriendsList();
     }
   }, [activeTab, isSearching]);
+
+  useEffect(() => {
+    if (!isMobile) return;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      if (modalRoot && modalRoot.children.length === 0) {
+        document.body.style.overflow = "unset";
+      }
+    };
+  }, [modalRoot, isMobile]);
 
   /* 친구 검색 */
   const handleSearch = (searchResults: FriendList[] | null) => {
@@ -458,7 +464,7 @@ const Layout = () => {
     !isEditMode &&
     isBadMannerValue?.mannerKeywordIdList.length !== 0;
 
-  return (
+  return createPortal(
     <>
       <Overlay $top={position.top} $left={position.left}>
         <Wrapper onClick={handleOutsideModalClick}>
@@ -727,7 +733,8 @@ const Layout = () => {
           </ModalSubmitBtn>
         </FormModal>
       )}
-    </>
+    </>,
+    modalRoot
   );
 };
 

--- a/src/components/chat/MessageHeader.tsx
+++ b/src/components/chat/MessageHeader.tsx
@@ -11,10 +11,11 @@ import {
   openChat,
   setChatRoomUuid,
 } from "@/redux/slices/chatSlice";
+import { setOpenAlertModal } from "@/redux/slices/modalSlice";
 import { theme } from "@/styles/theme";
 import { getProfileBgColor } from "@/utils";
 
-import { Alert, MoreBox } from "../common";
+import { MoreBox } from "../common";
 
 import type { RootState } from "@/redux/store";
 import type { Chat, MoreBoxMenuItems } from "@/types";
@@ -41,8 +42,6 @@ const MessageHeader = (props: MessageHeaderProps) => {
   const { isMobile } = useMediaQueryContext();
   const dispatch = useDispatch();
   const router = useRouter();
-  const [showAlert, setShowAlert] = useState<boolean>(false);
-
   const onlineFriends = useSelector(
     (state: RootState) => state.chat.onlineFriends
   );
@@ -55,7 +54,7 @@ const MessageHeader = (props: MessageHeaderProps) => {
 
   const handleGoToPrevious = () => {
     if (disabled) {
-      setShowAlert(true);
+      showLoginAlert();
     } else {
       dispatch(setChatRoomUuid(null));
       dispatch(closeChatRoom());
@@ -65,25 +64,27 @@ const MessageHeader = (props: MessageHeaderProps) => {
 
   const handleMoreBoxOpen = () => {
     if (disabled) {
-      setShowAlert(true);
+      showLoginAlert();
     } else {
       onMoreBoxOpen();
     }
   };
 
+  const showLoginAlert = () => {
+    dispatch(
+      setOpenAlertModal({
+        icon: "exclamation",
+        width: 68,
+        height: 58,
+        content: "로그인이 필요한 서비스입니다.",
+        alt: "경고",
+        buttonText: "확인",
+      })
+    );
+  };
+
   return (
     <>
-      {showAlert && (
-        <Alert
-          icon="exclamation"
-          width={68}
-          height={58}
-          content="로그인이 필요한 서비스입니다."
-          alt="경고"
-          onClose={() => setShowAlert(false)}
-          buttonText="확인"
-        />
-      )}
       {isMoreBoxOpen && (
         <MoreBox
           items={menuItems}

--- a/src/components/common/Alert.tsx
+++ b/src/components/common/Alert.tsx
@@ -1,14 +1,24 @@
+import { createPortal } from "react-dom";
+import { useDispatch, useSelector } from "react-redux";
 import Image from "next/image";
 import styled from "styled-components";
 
+import { setCloseAlertModal } from "@/redux/slices/modalSlice";
 import { theme } from "@/styles/theme";
 
-import type { AlertProps } from "@/types";
+import type { RootState } from "@/redux/store";
 
-const Alert = (props: AlertProps) => {
-  const { icon, width, height, content, alt, onClose, buttonText } = props;
+const Alert = () => {
+  const dispatch = useDispatch();
+  const showAlert = useSelector((state: RootState) => state.modal.isOpen);
+  const alertProps = useSelector((state: RootState) => state.modal.alertProps);
+  const modalRoot = document.getElementById("modal-root") as HTMLElement;
+  const { icon, width, height, content, alt, onClose, buttonText } =
+    alertProps || {};
 
-  return (
+  if (!showAlert) return null;
+
+  return createPortal(
     <Overlay>
       <Wrapper>
         <TextWrapper>
@@ -16,15 +26,29 @@ const Alert = (props: AlertProps) => {
             src={`/assets/icons/${icon}.svg`}
             width={width}
             height={height}
-            alt={alt}
+            alt={alt || ""}
           />
           <Text>{content}</Text>
         </TextWrapper>
         <ButtonWrapper>
-          <Button onClick={onClose}>{buttonText}</Button>
+          <Button
+            onClick={
+              onClose
+                ? () => {
+                    dispatch(setCloseAlertModal());
+                    onClose();
+                  }
+                : () => {
+                    dispatch(setCloseAlertModal());
+                  }
+            }
+          >
+            {buttonText}
+          </Button>
         </ButtonWrapper>
       </Wrapper>
-    </Overlay>
+    </Overlay>,
+    modalRoot
   );
 };
 

--- a/src/components/common/ChatButton.tsx
+++ b/src/components/common/ChatButton.tsx
@@ -6,16 +6,15 @@ import styled from "styled-components";
 import { STORAGE_KEY } from "@/constants/storage";
 import { useMediaQueryContext } from "@/hooks";
 import { toggleChat } from "@/redux/slices/chatSlice";
+import { setOpenAlertModal } from "@/redux/slices/modalSlice";
 import { theme } from "@/styles/theme";
 
 import Layout from "../chat/Layout";
-import Alert from "./Alert";
 
 import type { RootState } from "@/redux/store";
 
 const ChatButton = () => {
   const { isMobile } = useMediaQueryContext();
-  const [showAlert, setShowAlert] = useState(false);
   const [unreadChatUuids, setUnreadChatUuids] = useState<string[]>([]);
   const [chatCount, setChatCount] = useState<number>(0);
 
@@ -57,25 +56,27 @@ const ChatButton = () => {
 
   const handleToggleChat = () => {
     if (!isUser.gameName) {
-      return setShowAlert(true);
+      return showLoginAlert();
     }
     dispatch(toggleChat());
     // dispatch(resetPosition());
   };
 
+  const showLoginAlert = () => {
+    dispatch(
+      setOpenAlertModal({
+        icon: "exclamation",
+        width: 68,
+        height: 58,
+        content: "로그인이 필요한 서비스입니다.",
+        alt: "경고",
+        buttonText: "확인",
+      })
+    );
+  };
+
   return (
     <>
-      {showAlert && (
-        <Alert
-          icon="exclamation"
-          width={68}
-          height={58}
-          content="로그인이 필요한 서비스입니다."
-          alt="경고"
-          onClose={() => setShowAlert(false)}
-          buttonText="확인"
-        />
-      )}
       {isChatOpen && <Layout />}
       {isMobile ? (
         <MoMsgIconWrapper onClick={handleToggleChat}>

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
 import Image from "next/image";
 import styled from "styled-components";
@@ -8,6 +8,7 @@ import {
   setOpenModal,
 } from "@/redux/slices/modalSlice";
 import { theme } from "@/styles/theme";
+import { createPortal } from "react-dom";
 
 type ButtonText =
   | "취소"
@@ -44,8 +45,19 @@ const ConfirmModal = (props: ConfirmModalProps) => {
     onSecondaryClick,
   } = props;
 
+  const modalRoot = document.getElementById("modal-root") as HTMLElement;
   const dispatch = useDispatch();
+  useEffect(() => {
+    // 열릴 때
+    document.body.style.overflow = "hidden";
 
+    return () => {
+      // 닫힐 때
+      if(modalRoot && modalRoot.children.length === 0){
+        document.body.style.overflow = "unset";
+      }
+    };
+  }, [modalRoot]);
   let buttonClassName = "";
 
   if (type !== "manner") {
@@ -77,7 +89,7 @@ const ConfirmModal = (props: ConfirmModalProps) => {
       : dispatch(setOpenModal("badManner"));
   };
 
-  return (
+  return createPortal(
     <Overlay $type={type}>
       <Wrapper $width={width} $type={type} onClick={(e) => e.stopPropagation()}>
         <Main>
@@ -158,7 +170,7 @@ const ConfirmModal = (props: ConfirmModalProps) => {
         </Footer>
       </Wrapper>
     </Overlay>
-  );
+  ,modalRoot);
 };
 
 export default ConfirmModal;

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { useDispatch } from "react-redux";
 import Image from "next/image";
 import styled from "styled-components";
@@ -8,7 +9,6 @@ import {
   setOpenModal,
 } from "@/redux/slices/modalSlice";
 import { theme } from "@/styles/theme";
-import { createPortal } from "react-dom";
 
 type ButtonText =
   | "취소"
@@ -53,7 +53,7 @@ const ConfirmModal = (props: ConfirmModalProps) => {
 
     return () => {
       // 닫힐 때
-      if(modalRoot && modalRoot.children.length === 0){
+      if (modalRoot && modalRoot.children.length === 0) {
         document.body.style.overflow = "unset";
       }
     };
@@ -169,8 +169,9 @@ const ConfirmModal = (props: ConfirmModalProps) => {
           </ButtonWrapper>
         </Footer>
       </Wrapper>
-    </Overlay>
-  ,modalRoot);
+    </Overlay>,
+    modalRoot
+  );
 };
 
 export default ConfirmModal;

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -9,6 +9,7 @@ import {
   setOpenModal,
 } from "@/redux/slices/modalSlice";
 import { theme } from "@/styles/theme";
+import { lockBodyScroll, unlockBodyScroll } from "@/utils";
 
 type ButtonText =
   | "취소"
@@ -49,12 +50,12 @@ const ConfirmModal = (props: ConfirmModalProps) => {
   const dispatch = useDispatch();
   useEffect(() => {
     // 열릴 때
-    document.body.style.overflow = "hidden";
+    lockBodyScroll();
 
     return () => {
       // 닫힐 때
       if (modalRoot && modalRoot.children.length === 0) {
-        document.body.style.overflow = "unset";
+        unlockBodyScroll();
       }
     };
   }, [modalRoot]);

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
@@ -6,7 +6,6 @@ import styled from "styled-components";
 import { useMediaQueryContext } from "@/hooks";
 import { theme } from "@/styles/theme";
 
-import Alert from "./Alert";
 import ChatButton from "./ChatButton";
 import FeedBackInput from "./FeedbackInput";
 
@@ -18,12 +17,6 @@ const Footer = (props: FooterProps) => {
   const { isMobile } = useMediaQueryContext();
   const { isShowChat } = props;
   const router = useRouter();
-  const [showAlert, setShowAlert] = useState(false);
-
-  /* 서비스 준비 중 경고창 */
-  const handleShowWarning = () => {
-    setShowAlert(!showAlert);
-  };
 
   const handleDirectPrivacy = () => {
     router.push("/policy?terms=privacy");
@@ -35,17 +28,6 @@ const Footer = (props: FooterProps) => {
 
   return (
     <Wrapper>
-      {showAlert && (
-        <Alert
-          icon="exclamation"
-          width={68}
-          height={58}
-          content="서비스 준비 중입니다."
-          alt="경고"
-          onClose={handleShowWarning}
-          buttonText="확인"
-        />
-      )}
       <Container>
         <LeftWrapper>
           <LeftDiv>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -27,6 +27,8 @@ import {
   getProfileBgColor,
   getProfileImg,
   getUserId,
+  lockBodyScroll,
+  unlockBodyScroll,
 } from "@/utils";
 
 import AlertWindow from "../alert/AlertWindow";
@@ -106,14 +108,14 @@ const Header = () => {
   }, [isMyPage]);
 
   useEffect(() => {
-    document.body.style.overflow = "unset";
+    unlockBodyScroll();
 
     if (!isMobile) return;
 
     if (isMyPage) {
-      document.body.style.overflow = "hidden";
+      lockBodyScroll();
     } else {
-      document.body.style.overflow = "unset";
+      unlockBodyScroll();
     }
   }, [isMobile, isMyPage]);
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -106,6 +106,8 @@ const Header = () => {
   }, [isMyPage]);
 
   useEffect(() => {
+    document.body.style.overflow = "unset";
+
     if (!isMobile) return;
 
     if (isMyPage) {

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useDispatch, useSelector } from "react-redux";
 import Image from "next/image";
 import Link from "next/link";
@@ -29,7 +30,6 @@ import {
 } from "@/utils";
 
 import AlertWindow from "../alert/AlertWindow";
-import Alert from "./Alert";
 import ChatButton from "./ChatButton";
 
 import type { RootState } from "@/redux/store";
@@ -61,6 +61,7 @@ const Header = () => {
   const storedUserId = Number(getUserId());
 
   const isFirstRender = useRef(true);
+  const modalRoot = document.getElementById("modal-root") as HTMLElement;
 
   useEffect(
     () => {
@@ -103,6 +104,16 @@ const Header = () => {
       document.addEventListener("mousedown", handleClickOutside);
     }
   }, [isMyPage]);
+
+  useEffect(() => {
+    if (!isMobile) return;
+
+    if (isMyPage) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "unset";
+    }
+  }, [isMobile, isMyPage]);
 
   /* 페이지 이동 시 팝업창 닫음 */
   useEffect(() => {
@@ -218,11 +229,6 @@ const Header = () => {
               ref={myPageDivRef}
               className="profile"
               onClick={() => {
-                // if (isMobile) {
-                //   router.push("/mypage/profile");
-                //   return;
-                // }
-
                 setIsMyPage(!isMyPage);
               }}
             >
@@ -259,86 +265,90 @@ const Header = () => {
           alertButtonRef={alertButtonRef}
         />
       )}
-      {isMyPage && (
-        <MyPageModal ref={myPageRef}>
-          {isMobile && (
-            <MyPageModalHeader>
-              <MyPageModalHeaderTitle>내정보</MyPageModalHeaderTitle>
-              <button>
-                <Image
-                  src="/assets/icons/close_modal.svg"
-                  width={16}
-                  height={16}
-                  alt="닫기"
-                  onClick={() => setIsMyPage(false)}
-                  style={{ cursor: "pointer" }}
-                />
-              </button>
-            </MyPageModalHeader>
-          )}
-
-          <MyProfile>
-            {profileImg && (
-              <ProfileImgWrapper $bgColor={getProfileBgColor(profileImg)}>
-                <ProfileImg
-                  data={`/assets/images/profile/profile${profileImg}.svg`}
-                  width={52}
-                  height={62}
-                />
-              </ProfileImgWrapper>
-            )}
-            <MyName>{name}</MyName>
-            <Image
-              src={`/assets/icons/noti_${notiCount > 0 ? "on" : "off"}.svg`}
-              width={24}
-              height={30}
-              alt="noti"
-              onClick={() => {
-                router.push("/mypage/notification");
-                setIsMyPage(false);
-              }}
-              style={{ cursor: "pointer" }}
-            />
-          </MyProfile>
-          <TabMenu>
-            {HEADER_MODAL_TAB.map((data, index) => (
-              <TabItemWrapper key={data.id}>
-                <Line
-                  onClick={async () => {
-                    setIsMyPage(false);
-                    if (data.id !== 6) {
-                      router.push(`${data.url}`);
-                    } else {
-                      sessionStorage.setItem(STORAGE_KEY.logout, "true");
-                      try {
-                        await postLogout();
-                        await clearTokens();
-                        await socketLogout();
-                        localStorage.removeItem(STORAGE_KEY.gamegooSocketId);
-                        dispatch(clearUserProfile());
-                        sessionStorage.removeItem(STORAGE_KEY.unreadChatUuids);
-                        dispatch(closeChat());
-                        router.push("/riot");
-                      } catch {
-                        console.error("소켓 로그아웃 오류");
-                      }
-                    }
-                  }}
-                >
+      {isMyPage &&
+        createPortal(
+          <MyPageModal ref={myPageRef}>
+            {isMobile && (
+              <MyPageModalHeader>
+                <MyPageModalHeaderTitle>내정보</MyPageModalHeaderTitle>
+                <button>
                   <Image
-                    src={`/assets/icons/${data.icon}.svg`}
-                    width={20}
-                    height={20}
-                    alt={`${data.icon}`}
+                    src="/assets/icons/close_modal.svg"
+                    width={16}
+                    height={16}
+                    alt="닫기"
+                    onClick={() => setIsMyPage(false)}
+                    style={{ cursor: "pointer" }}
                   />
-                  {data.menu}
-                </Line>
-                {index === 3 && <Divider />}
-              </TabItemWrapper>
-            ))}
-          </TabMenu>
-        </MyPageModal>
-      )}
+                </button>
+              </MyPageModalHeader>
+            )}
+
+            <MyProfile>
+              {profileImg && (
+                <ProfileImgWrapper $bgColor={getProfileBgColor(profileImg)}>
+                  <ProfileImg
+                    data={`/assets/images/profile/profile${profileImg}.svg`}
+                    width={52}
+                    height={62}
+                  />
+                </ProfileImgWrapper>
+              )}
+              <MyName>{name}</MyName>
+              <Image
+                src={`/assets/icons/noti_${notiCount > 0 ? "on" : "off"}.svg`}
+                width={24}
+                height={30}
+                alt="noti"
+                onClick={() => {
+                  router.push("/mypage/notification");
+                  setIsMyPage(false);
+                }}
+                style={{ cursor: "pointer" }}
+              />
+            </MyProfile>
+            <TabMenu>
+              {HEADER_MODAL_TAB.map((data, index) => (
+                <TabItemWrapper key={data.id}>
+                  <Line
+                    onClick={async () => {
+                      setIsMyPage(false);
+                      if (data.id !== 6) {
+                        router.push(`${data.url}`);
+                      } else {
+                        sessionStorage.setItem(STORAGE_KEY.logout, "true");
+                        try {
+                          await postLogout();
+                          await clearTokens();
+                          await socketLogout();
+                          localStorage.removeItem(STORAGE_KEY.gamegooSocketId);
+                          dispatch(clearUserProfile());
+                          sessionStorage.removeItem(
+                            STORAGE_KEY.unreadChatUuids
+                          );
+                          dispatch(closeChat());
+                          router.push("/riot");
+                        } catch {
+                          console.error("소켓 로그아웃 오류");
+                        }
+                      }
+                    }}
+                  >
+                    <Image
+                      src={`/assets/icons/${data.icon}.svg`}
+                      width={20}
+                      height={20}
+                      alt={`${data.icon}`}
+                    />
+                    {data.menu}
+                  </Line>
+                  {index === 3 && <Divider />}
+                </TabItemWrapper>
+              ))}
+            </TabMenu>
+          </MyPageModal>,
+          modalRoot
+        )}
     </Head>
   );
 };

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -10,6 +10,7 @@ import { HEADER_MODAL_TAB } from "@/constants";
 import { STORAGE_KEY } from "@/constants/storage";
 import { useMediaQueryContext } from "@/hooks";
 import { closeChat } from "@/redux/slices/chatSlice";
+import { setOpenAlertModal } from "@/redux/slices/modalSlice";
 import { setNotiCount } from "@/redux/slices/notiSlice";
 import {
   clearUserProfile,
@@ -54,7 +55,6 @@ const Header = () => {
   const myPageDivRef = useRef<HTMLDivElement>(null);
 
   const myPageRef = useRef<HTMLDivElement>(null);
-  const [showAlert, setShowAlert] = useState(false);
 
   const storedName = getName();
   const storedProfileImg = Number(getProfileImg());
@@ -119,6 +119,18 @@ const Header = () => {
     }
   };
 
+  const showLoginAlert = () => {
+    dispatch(
+      setOpenAlertModal({
+        icon: "exclamation",
+        width: 68,
+        height: 58,
+        content: "로그인이 필요한 서비스입니다.",
+        alt: "경고",
+        buttonText: "확인",
+      })
+    );
+  };
   useEffect(
     () => {
       // 첫 렌더에서만 API 호출
@@ -135,18 +147,6 @@ const Header = () => {
 
   return (
     <Head>
-      {showAlert && (
-        <Alert
-          icon="exclamation"
-          width={68}
-          height={58}
-          content="로그인이 필요한 서비스입니다."
-          alt="경고"
-          onClose={() => setShowAlert(false)}
-          buttonText="확인"
-        />
-      )}
-
       <HeaderBar>
         <LogoButton>
           <Link href="/">
@@ -178,7 +178,7 @@ const Header = () => {
             selected={pathname.includes("/match")}
             onClick={() => {
               if (!accesssToken) {
-                setShowAlert(true);
+                showLoginAlert();
               } else {
                 router.push("/match");
               }

--- a/src/components/common/ModalContainer.tsx
+++ b/src/components/common/ModalContainer.tsx
@@ -1,0 +1,11 @@
+import Alert from "@/components/common/Alert";
+
+const ModalContainer = () => {
+  return (
+    <>
+      <Alert />
+    </>
+  );
+};
+
+export default ModalContainer;

--- a/src/components/common/PostItem/PostItemModal.tsx
+++ b/src/components/common/PostItem/PostItemModal.tsx
@@ -95,6 +95,9 @@ const Msg = styled.div`
   color: ${theme.colors.gray800};
   ${(props) => props.theme.fonts.regular25};
   margin: 28px 0;
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    ${(props) => props.theme.fonts.medium14};
+  }
 `;
 
 const MsgConfirm = styled(Msg)`

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -22,6 +22,7 @@ export { default as MannerLevelBar } from "./MannerLevelBar";
 export { default as MannerLevelBox } from "./MannerLevelBox";
 export { default as Mic } from "./Mic";
 export { default as MoreBox } from "./MoreBox";
+export { default as ModalContainer } from "./ModalContainer";
 export { default as Pagination } from "./Pagination";
 export { default as PositionCategory } from "./PositionCategory";
 export { default as ProtectRoute } from "./ProtectRoute";

--- a/src/components/createBoard/PostBoard.tsx
+++ b/src/components/createBoard/PostBoard.tsx
@@ -12,7 +12,10 @@ import styled from "styled-components";
 
 import { editPost, getMyProfile, postBoard } from "@/api";
 import { GAME_MODE } from "@/constants";
-import { setClosePostingModal } from "@/redux/slices/modalSlice";
+import {
+  setClosePostingModal,
+  setOpenAlertModal,
+} from "@/redux/slices/modalSlice";
 import {
   clearCurrentPost,
   setPostStatus,
@@ -84,7 +87,6 @@ const PostBoard = (props: PostBoardProps) => {
     currentPost?.contents || ""
   );
   const [isFocused, setIsFocused] = useState<boolean>(false);
-  const [showAlert, setShowAlert] = useState(false);
 
   const fetchProfile = async () => {
     try {
@@ -203,11 +205,25 @@ const PostBoard = (props: PostBoardProps) => {
     }
   };
 
+  const showLoginAlert = () => {
+    dispatch(
+      setOpenAlertModal({
+        icon: "exclamation",
+        width: 68,
+        height: 58,
+        content: "로그아웃 되었습니다. 다시 로그인 해주세요.",
+        alt: "로그인 필요",
+        buttonText: "로그인하기",
+        onClose: () => router.push("/riot"),
+      })
+    );
+  };
+
   /* 글쓰기 */
   const handlePost = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!user.gameName) {
-      return setShowAlert(true);
+      return showLoginAlert();
     }
 
     const isARAM = selectedDropOption === "ARAM"; // 칼바람
@@ -279,18 +295,6 @@ const PostBoard = (props: PostBoardProps) => {
 
   return (
     <CRModal type="posting" onClose={handleModalClose}>
-      {showAlert && (
-        <Alert
-          icon="exclamation"
-          width={68}
-          height={58}
-          content="로그아웃 되었습니다. 다시 로그인 해주세요."
-          alt="로그인 필요"
-          onClose={() => router.push("/riot")}
-          buttonText="로그인하기"
-        />
-      )}
-
       {postStatus && (
         <ConfirmModal
           width="540px"

--- a/src/components/match/SelectedStylePopup.tsx
+++ b/src/components/match/SelectedStylePopup.tsx
@@ -140,7 +140,7 @@ const Container = styled.div<{
     content: "";
     position: absolute;
     top: -18px;
-    left: ${({ $tailLeft }) => $tailLeft+5}px;
+    left: ${({ $tailLeft }) => $tailLeft + 5}px;
   }
 
   @media (max-width: ${theme.breakpoints.desktop}) {

--- a/src/components/mypage/post/MoPost.tsx
+++ b/src/components/mypage/post/MoPost.tsx
@@ -3,12 +3,13 @@ import { useDispatch, useSelector } from "react-redux";
 import { useRouter } from "next/navigation";
 
 import { getMemberPost, getNonMemberPost } from "@/api";
-import { Alert, PostItem } from "@/components/common";
+import { PostItem } from "@/components/common";
+import { setOpenAlertModal } from "@/redux/slices/modalSlice";
 
 import type { AxiosError } from "axios";
 import type { PostItemData } from "@/components/common";
 import type { RootState } from "@/redux/store";
-import type { AlertProps, MemberPost, User } from "@/types";
+import type { MemberPost, User } from "@/types";
 
 export interface PostProps {
   user: User;
@@ -46,17 +47,6 @@ const MoPost: React.FC<PostProps> = ({
 
   const [isPost, setIsPost] = useState<MemberPost>();
   const [loading, setLoading] = useState(true);
-  const [showAlert, setShowAlert] = useState(false);
-  const [alertProps, setAlertProps] = useState<AlertProps>({
-    icon: "",
-    width: 0,
-    height: 0,
-    content: "",
-    alt: "",
-    onClose: () => {},
-    buttonText: "",
-  });
-
   const isUser = useSelector((state: RootState) => state.user);
 
   const deletedMessage = "해당 글은 삭제된 글입니다.";
@@ -64,19 +54,18 @@ const MoPost: React.FC<PostProps> = ({
   const showAlertWithContent = (
     icon: string,
     content: string,
-    handleAlertClose: () => void,
     btnText: string
   ) => {
-    setAlertProps({
-      icon: icon,
-      width: 68,
-      height: 58,
-      content: content,
-      alt: "경고",
-      onClose: handleAlertClose,
-      buttonText: btnText,
-    });
-    setShowAlert(true);
+    dispatch(
+      setOpenAlertModal({
+        icon: icon,
+        width: 68,
+        height: 58,
+        content: content,
+        alt: "경고",
+        buttonText: btnText,
+      })
+    );
   };
 
   /* 게시글 api */
@@ -96,14 +85,7 @@ const MoPost: React.FC<PostProps> = ({
       if (
         axiosError?.response?.data?.message === "해당 글은 삭제된 글입니다."
       ) {
-        return showAlertWithContent(
-          "trash",
-          deletedMessage,
-          () => {
-            setShowAlert(false);
-          },
-          "확인"
-        );
+        return showAlertWithContent("trash", deletedMessage, "확인");
       } else {
         console.error(error);
       }
@@ -150,8 +132,6 @@ const MoPost: React.FC<PostProps> = ({
 
   return (
     <>
-      {showAlert ? <Alert {...alertProps} /> : null}
-
       <PostItem
         data={postItemData}
         variant="mypage"

--- a/src/components/mypage/post/Post.tsx
+++ b/src/components/mypage/post/Post.tsx
@@ -97,8 +97,8 @@ const Post: React.FC<PostProps> = ({
       setCurrentPost({ currentPost: memberData.data, currentPostId: boardId })
     );
     setIsPost(memberData.data);
-    dispatch(setOpenPostingModal());
     dispatch(setCloseReadingModal());
+    dispatch(setOpenPostingModal());
     setIsMoreBoxOpen(false);
     dispatch(setPostStatus(""));
   };

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -1048,11 +1048,18 @@ const Msg = styled.div`
   color: ${theme.colors.gray600};
   ${(props) => props.theme.fonts.regular20};
   margin: 28px 0;
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    ${(props) => props.theme.fonts.medium14};
+  }
 `;
 
 const MsgConfirm = styled(Msg)`
   ${(props) => props.theme.fonts.regular20};
   margin: 80px 0;
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    ${(props) => props.theme.fonts.medium14};
+    margin: 32px 0;
+  }
 `;
 
 const Positions = styled.div`

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -35,6 +35,7 @@ import {
 import { POSITIONS, REPORT_REASON } from "@/constants";
 import { useMediaQueryContext } from "@/hooks";
 import { setMatchInfo, updateMike } from "@/redux/slices/matchInfo";
+import { setOpenAlertModal } from "@/redux/slices/modalSlice";
 import { setUserProfileImg } from "@/redux/slices/userSlice";
 import { theme } from "@/styles/theme";
 import { setPositionImg } from "@/utils/custom";
@@ -481,25 +482,27 @@ const Profile: React.FC<Profile> = ({
 
   const handleMoreBoxOpen = () => {
     if (isDefault) {
-      setShowAlert(true);
+      showLoginAlert();
     } else {
       setIsMoreBoxOpen((prevState) => !prevState);
     }
   };
 
+  const showLoginAlert = () => {
+    dispatch(
+      setOpenAlertModal({
+        icon: "exclamation",
+        width: 68,
+        height: 58,
+        content: "로그인이 필요한 서비스입니다.",
+        alt: "경고",
+        buttonText: "확인",
+      })
+    );
+  };
+
   return (
     <Container className={profileType} $backgroundColor={backgroundColor}>
-      {showAlert && (
-        <Alert
-          icon="exclamation"
-          width={68}
-          height={58}
-          content="로그인이 필요한 서비스입니다."
-          alt="경고"
-          onClose={() => setShowAlert(false)}
-          buttonText="확인"
-        />
-      )}
       <Row $profileType={profileType}>
         <ImageContainer>
           <UpdateProfileImage

--- a/src/components/readBoard/ReadBoard.tsx
+++ b/src/components/readBoard/ReadBoard.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/redux/slices/chatSlice";
 import {
   setCloseReadingModal,
+  setOpenAlertModal,
   setOpenModal,
   setOpenPostingModal,
 } from "@/redux/slices/modalSlice";
@@ -111,19 +112,20 @@ const ReadBoard = (props: ReadBoardProps) => {
   const showAlertWithContent = (
     icon: string,
     content: string,
-    handleAlertClose: () => void,
-    btnText: string
+    btnText: string,
+    handleAlertClose?: () => void
   ) => {
-    setAlertProps({
-      icon: icon,
-      width: 68,
-      height: 58,
-      content: content,
-      alt: "경고",
-      onClose: handleAlertClose,
-      buttonText: btnText,
-    });
-    setShowAlert(true);
+    dispatch(
+      setOpenAlertModal({
+        icon: icon,
+        width: 68,
+        height: 58,
+        content: content,
+        alt: "경고",
+        onClose: handleAlertClose,
+        buttonText: btnText,
+      })
+    );
   };
 
   /* 게시글 api */
@@ -145,15 +147,9 @@ const ReadBoard = (props: ReadBoardProps) => {
       if (
         axiosError?.response?.data?.message === "해당 글은 삭제된 글입니다."
       ) {
-        return showAlertWithContent(
-          "trash",
-          deletedMessage,
-          () => {
-            setShowAlert(false);
-            dispatch(setCloseReadingModal());
-          },
-          "확인"
-        );
+        return showAlertWithContent("trash", deletedMessage, "확인", () => {
+          dispatch(setCloseReadingModal());
+        });
       } else {
         console.error(error);
       }
@@ -205,8 +201,8 @@ const ReadBoard = (props: ReadBoardProps) => {
       return showAlertWithContent(
         "exclamation",
         logoutMessage,
-        () => router.push("/riot"),
-        "로그인하기"
+        "로그인하기",
+        () => router.push("/riot")
       );
     }
 
@@ -225,8 +221,8 @@ const ReadBoard = (props: ReadBoardProps) => {
       return showAlertWithContent(
         "exclamation",
         logoutMessage,
-        () => router.push("/riot"),
-        "로그인하기"
+        "로그인하기",
+        () => router.push("/riot")
       );
     }
 
@@ -252,8 +248,8 @@ const ReadBoard = (props: ReadBoardProps) => {
       return showAlertWithContent(
         "exclamation",
         logoutMessage,
-        () => router.push("/riot"),
-        "로그인하기"
+        "로그인하기",
+        () => router.push("/riot")
       );
     }
 
@@ -277,8 +273,8 @@ const ReadBoard = (props: ReadBoardProps) => {
       return showAlertWithContent(
         "exclamation",
         logoutMessage,
-        () => router.push("/riot"),
-        "로그인하기"
+        "로그인하기",
+        () => router.push("/riot")
       );
     }
 
@@ -302,8 +298,8 @@ const ReadBoard = (props: ReadBoardProps) => {
       return showAlertWithContent(
         "exclamation",
         logoutMessage,
-        () => router.push("/riot"),
-        "로그인하기"
+        "로그인하기",
+        () => router.push("/riot")
       );
     }
 
@@ -324,12 +320,7 @@ const ReadBoard = (props: ReadBoardProps) => {
   /* 매너레벨 박스 열기 */
   const handleMannerLevelBoxOpen = () => {
     if (!isUser.id) {
-      return showAlertWithContent(
-        "exclamation",
-        loginRequiredMessage,
-        () => setShowAlert(false),
-        "확인"
-      );
+      return showAlertWithContent("exclamation", loginRequiredMessage, "확인");
     }
 
     setIsMannerLevelBoxOpen((prevState) => !prevState);
@@ -341,8 +332,8 @@ const ReadBoard = (props: ReadBoardProps) => {
       return showAlertWithContent(
         "exclamation",
         logoutMessage,
-        () => router.push("/riot"),
-        "로그인하기"
+        "로그인하기",
+        () => router.push("/riot")
       );
     }
 
@@ -372,8 +363,8 @@ const ReadBoard = (props: ReadBoardProps) => {
       return showAlertWithContent(
         "exclamation",
         logoutMessage,
-        () => router.push("/riot"),
-        "로그인하기"
+        "로그인하기",
+        () => router.push("/riot")
       );
     }
 
@@ -396,8 +387,8 @@ const ReadBoard = (props: ReadBoardProps) => {
       return showAlertWithContent(
         "exclamation",
         logoutMessage,
-        () => router.push("/riot"),
-        "로그인하기"
+        "로그인하기",
+        () => router.push("/riot")
       );
     }
 
@@ -416,12 +407,7 @@ const ReadBoard = (props: ReadBoardProps) => {
   /* 더보기 버튼 토글 */
   const handleMoreBoxToggle = () => {
     if (!isUser.id) {
-      return showAlertWithContent(
-        "exclamation",
-        loginRequiredMessage,
-        () => setShowAlert(false),
-        "확인"
-      );
+      return showAlertWithContent("exclamation", loginRequiredMessage, "확인");
     }
 
     setIsMoreBoxOpen((prevState) => !prevState);
@@ -542,147 +528,141 @@ const ReadBoard = (props: ReadBoardProps) => {
         hideContent={showAlert}
         onClose={() => dispatch(setCloseReadingModal())}
       >
-        {showAlert ? (
-          <Alert {...alertProps} />
-        ) : (
-          isPost && (
-            <>
-              {isMoreBoxOpen && (
-                <MoreBox
-                  items={MoreBoxMenuItems}
-                  top={67}
-                  right={45}
-                  onClose={() => setIsMoreBoxOpen(false)}
+        {isPost && (
+          <>
+            {isMoreBoxOpen && (
+              <MoreBox
+                items={MoreBoxMenuItems}
+                top={67}
+                right={45}
+                onClose={() => setIsMoreBoxOpen(false)}
+              />
+            )}
+            <Wrapper>
+              <UserSection>
+                <UserLeft>
+                  <UserProfileWrapper>
+                    <ProfileImage image={isPost.profileImage} />
+                    <UserNManner>
+                      <MannerLevelWrapper>
+                        <MannerLevel
+                          level={isPost.mannerLevel}
+                          onClick={handleMannerLevelBoxOpen}
+                          position="board"
+                        />
+                        {isMannerLevelBoxOpen && (
+                          <div ref={mannerLevelBoxRef}>
+                            <MannerLevelBox
+                              memberId={isPost.memberId}
+                              level={isPost.mannerLevel}
+                              top="40px"
+                              right="-780%"
+                              tail={true}
+                              tailPosition="top"
+                              onClose={() =>
+                                setIsMannerLevelBoxOpen(!isMannerLevelBoxOpen)
+                              }
+                            />
+                          </div>
+                        )}
+                      </MannerLevelWrapper>
+                    </UserNManner>
+                  </UserProfileWrapper>
+                  <UserAccount
+                    account={isPost.gameName}
+                    memberId={isPost.memberId}
+                    mike={isPost.mike}
+                    tag={isPost.tag}
+                  />
+                </UserLeft>
+                <UserRight>
+                  <MoreBoxButton onClick={handleMoreBoxToggle} />
+                </UserRight>
+              </UserSection>
+              <UserTierWrapper>
+                <RankTier
+                  type="solo"
+                  tier={isPost.soloTier || ""}
+                  rank={isPost.soloRank}
+                  direct="column"
+                  color={theme.colors.gray800}
+                  tierFontSize={theme.fonts.bold20}
                 />
+                <RankTier
+                  type="free"
+                  tier={isPost.freeTier || ""}
+                  rank={isPost.freeRank}
+                  direct="column"
+                  color={theme.colors.gray800}
+                  tierFontSize={theme.fonts.bold20}
+                />
+              </UserTierWrapper>
+              {gameMode !== "ARAM" && (
+                <PositionSection>
+                  <Title>포지션</Title>
+                  <PositionBox
+                    status="reading"
+                    main={isPost.mainP || null}
+                    sub={isPost.subP || null}
+                    want={
+                      Array.isArray(isPost.wantP)
+                        ? isPost.wantP.filter((v) => v !== null)
+                        : null
+                    }
+                  />
+                </PositionSection>
               )}
-              <Wrapper>
-                <UserSection>
-                  <UserLeft>
-                    <UserProfileWrapper>
-                      <ProfileImage image={isPost.profileImage} />
-                      <UserNManner>
-                        <MannerLevelWrapper>
-                          <MannerLevel
-                            level={isPost.mannerLevel}
-                            onClick={handleMannerLevelBoxOpen}
-                            position="board"
-                          />
-                          {isMannerLevelBoxOpen && (
-                            <div ref={mannerLevelBoxRef}>
-                              <MannerLevelBox
-                                memberId={isPost.memberId}
-                                level={isPost.mannerLevel}
-                                top="40px"
-                                right="-780%"
-                                tail={true}
-                                tailPosition="top"
-                                onClose={() =>
-                                  setIsMannerLevelBoxOpen(!isMannerLevelBoxOpen)
-                                }
-                              />
-                            </div>
-                          )}
-                        </MannerLevelWrapper>
-                      </UserNManner>
-                    </UserProfileWrapper>
-                    <UserAccount
-                      account={isPost.gameName}
-                      memberId={isPost.memberId}
-                      mike={isPost.mike}
-                      tag={isPost.tag}
-                    />
-                  </UserLeft>
-                  <UserRight>
-                    <MoreBoxButton onClick={handleMoreBoxToggle} />
-                  </UserRight>
-                </UserSection>
-                <UserTierWrapper>
-                  <RankTier
-                    type="solo"
-                    tier={isPost.soloTier || ""}
-                    rank={isPost.soloRank}
-                    direct="column"
-                    color={theme.colors.gray800}
-                    tierFontSize={theme.fonts.bold20}
-                  />
-                  <RankTier
-                    type="free"
-                    tier={isPost.freeTier || ""}
-                    rank={isPost.freeRank}
-                    direct="column"
-                    color={theme.colors.gray800}
-                    tierFontSize={theme.fonts.bold20}
-                  />
-                </UserTierWrapper>
-                {gameMode !== "ARAM" && (
-                  <PositionSection>
-                    <Title>포지션</Title>
-                    <PositionBox
-                      status="reading"
-                      main={isPost.mainP || null}
-                      sub={isPost.subP || null}
-                      want={
-                        Array.isArray(isPost.wantP)
-                          ? isPost.wantP.filter((v) => v !== null)
-                          : null
-                      }
-                    />
-                  </PositionSection>
-                )}
-                <ChampionNQueueSection>
-                  <QueueType value={isPost.gameMode} />
-                  <Champion
-                    title={true}
-                    font="semiBold14"
-                    list={isPost?.championStatsResponseList}
-                  />
-                </ChampionNQueueSection>
-                <WinningRateSection $gameType={gameMode}>
-                  <WinningRate
-                    completed={isPost.winRate}
-                    recentGameCount={isPost?.recentGameCount}
-                  />
-                </WinningRateSection>
-                <StyleSection $gameType={gameMode}>
-                  <Title>게임 스타일</Title>
-                  <GameStyle styles={isPost.gameStyles} />
-                </StyleSection>
-                <MemoSection $gameType={gameMode}>
-                  <Title>한마디</Title>
-                  <Memo>
-                    <MemoData>{isPost.contents}</MemoData>
-                  </Memo>
-                  <UpdatedDate>
-                    게시일 :{" "}
-                    {setPostingDateFormatter(
-                      isPost.bumpTime || isPost.createdAt
-                    )}
-                  </UpdatedDate>
-                </MemoSection>
-              </Wrapper>
-              {isUser.gameName !== isPost.gameName ? (
-                <ButtonContent $gameType={gameMode}>
-                  <Button
-                    type="submit"
-                    buttonType="primary"
-                    text={"말 걸어보기"}
-                    onClick={handleChatStart}
-                  />
-                </ButtonContent>
-              ) : (
-                // isPostStatus === "pullup" && (
-                <ButtonContent $gameType={gameMode}>
-                  <Button
-                    type="submit"
-                    buttonType="primary"
-                    text={"끌어올리기"}
-                    onClick={handlePullUpAction}
-                  />
-                </ButtonContent>
-                // )
-              )}
-            </>
-          )
+              <ChampionNQueueSection>
+                <QueueType value={isPost.gameMode} />
+                <Champion
+                  title={true}
+                  font="semiBold14"
+                  list={isPost?.championStatsResponseList}
+                />
+              </ChampionNQueueSection>
+              <WinningRateSection $gameType={gameMode}>
+                <WinningRate
+                  completed={isPost.winRate}
+                  recentGameCount={isPost?.recentGameCount}
+                />
+              </WinningRateSection>
+              <StyleSection $gameType={gameMode}>
+                <Title>게임 스타일</Title>
+                <GameStyle styles={isPost.gameStyles} />
+              </StyleSection>
+              <MemoSection $gameType={gameMode}>
+                <Title>한마디</Title>
+                <Memo>
+                  <MemoData>{isPost.contents}</MemoData>
+                </Memo>
+                <UpdatedDate>
+                  게시일 :{" "}
+                  {setPostingDateFormatter(isPost.bumpTime || isPost.createdAt)}
+                </UpdatedDate>
+              </MemoSection>
+            </Wrapper>
+            {isUser.gameName !== isPost.gameName ? (
+              <ButtonContent $gameType={gameMode}>
+                <Button
+                  type="submit"
+                  buttonType="primary"
+                  text={"말 걸어보기"}
+                  onClick={handleChatStart}
+                />
+              </ButtonContent>
+            ) : (
+              // isPostStatus === "pullup" && (
+              <ButtonContent $gameType={gameMode}>
+                <Button
+                  type="submit"
+                  buttonType="primary"
+                  text={"끌어올리기"}
+                  onClick={handlePullUpAction}
+                />
+              </ButtonContent>
+              // )
+            )}
+          </>
         )}
       </CRModal>
 

--- a/src/components/readBoard/ReadBoard.tsx
+++ b/src/components/readBoard/ReadBoard.tsx
@@ -383,8 +383,8 @@ const ReadBoard = (props: ReadBoardProps) => {
       await dispatch(
         setCurrentPost({ currentPost: isPost, currentPostId: postId })
       );
-      await dispatch(setOpenPostingModal());
       await dispatch(setCloseReadingModal());
+      await dispatch(setOpenPostingModal());
       dispatch(setPostStatus(""));
     }
     console.log("isPostModalOpen 상태:", isPostModalOpen);
@@ -923,9 +923,16 @@ const Msg = styled.div`
   color: ${theme.colors.gray800};
   ${(props) => props.theme.fonts.regular25};
   margin: 28px 0;
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    ${(props) => props.theme.fonts.medium14};
+  }
 `;
 
 const MsgConfirm = styled(Msg)`
   ${(props) => props.theme.fonts.regular25};
   margin: 80px 0;
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    ${(props) => props.theme.fonts.medium14};
+    margin: 32px 0;
+  }
 `;

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -429,6 +429,7 @@ const RecentBox = styled.div`
   gap: 56px;
 
   @media (max-width: ${theme.breakpoints.mobile}) {
+    height: unset;
     display: flex;
     flex-direction: column;
     align-items: flex-start;

--- a/src/redux/slices/modalSlice.ts
+++ b/src/redux/slices/modalSlice.ts
@@ -1,12 +1,26 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { lockBodyScroll, unlockBodyScroll } from "@/utils";
 
-interface ModalState {
+import { decrementModalCount, incrementModalCount } from "@/utils";
+
+import type { PayloadAction } from "@reduxjs/toolkit";
+
+interface AlertPayload {
+  icon: string;
+  width: number;
+  height: number;
+  content: string;
+  alt: string;
+  buttonText: string;
+  onClose?: () => void;
+}
+export interface ModalState {
   isOpen: boolean;
   evaluationModal: boolean;
   modalType: string;
   readingModal: boolean;
   postingModal: boolean;
+  alertProps: AlertPayload | undefined;
+  openCount: number;
 }
 
 const initialState: ModalState = {
@@ -15,6 +29,8 @@ const initialState: ModalState = {
   modalType: "",
   readingModal: false,
   postingModal: false,
+  alertProps: undefined,
+  openCount: 0,
 };
 
 const modalSlice = createSlice({
@@ -24,46 +40,57 @@ const modalSlice = createSlice({
     /* 매너,비매너 선택 모달 */
     setOpenMannerStatusModal: (state) => {
       state.isOpen = true;
-      lockBodyScroll();
+      incrementModalCount(state);
     },
     setCloseMannerStatusModal: (state) => {
       state.isOpen = false;
-      unlockBodyScroll();
+      decrementModalCount(state);
     },
     /* 매너,비매너 평가하기 모달 */
     setOpenEvaluationModal: (state) => {
       state.evaluationModal = true;
-      lockBodyScroll();
+      incrementModalCount(state);
     },
     setCloseEvaluationModal: (state) => {
       state.evaluationModal = false;
-      unlockBodyScroll();
+      decrementModalCount(state);
     },
     setOpenModal: (state, action) => {
       state.modalType = action.payload;
-      lockBodyScroll();
+      incrementModalCount(state);
     },
     setCloseModal: (state) => {
       state.modalType = "";
-      unlockBodyScroll();
+      decrementModalCount(state);
     },
     /* 게시판 읽기 모달 */
     setOpenReadingModal: (state) => {
       state.readingModal = true;
-      lockBodyScroll();
+      incrementModalCount(state);
     },
     setCloseReadingModal: (state) => {
       state.readingModal = false;
-      unlockBodyScroll();
+      decrementModalCount(state);
     },
     /* 게시판 쓰기 모달 */
     setOpenPostingModal: (state) => {
       state.postingModal = true;
-      lockBodyScroll();
+      incrementModalCount(state);
     },
     setClosePostingModal: (state) => {
       state.postingModal = false;
-      unlockBodyScroll();
+      decrementModalCount(state);
+    },
+    /* Alert Component */
+    setOpenAlertModal: (state, action: PayloadAction<AlertPayload>) => {
+      state.isOpen = true;
+      state.alertProps = action.payload;
+      incrementModalCount(state);
+    },
+    setCloseAlertModal: (state) => {
+      state.isOpen = false;
+      state.alertProps = undefined;
+      decrementModalCount(state);
     },
   },
 });
@@ -79,6 +106,8 @@ export const {
   setCloseReadingModal,
   setOpenPostingModal,
   setClosePostingModal,
+  setOpenAlertModal,
+  setCloseAlertModal,
 } = modalSlice.actions;
 
 export default modalSlice.reducer;

--- a/src/redux/slices/modalSlice.ts
+++ b/src/redux/slices/modalSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
+import { lockBodyScroll, unlockBodyScroll } from "@/utils";
 
 interface ModalState {
   isOpen: boolean;
@@ -23,36 +24,46 @@ const modalSlice = createSlice({
     /* 매너,비매너 선택 모달 */
     setOpenMannerStatusModal: (state) => {
       state.isOpen = true;
+      lockBodyScroll();
     },
     setCloseMannerStatusModal: (state) => {
       state.isOpen = false;
+      unlockBodyScroll();
     },
     /* 매너,비매너 평가하기 모달 */
     setOpenEvaluationModal: (state) => {
       state.evaluationModal = true;
+      lockBodyScroll();
     },
     setCloseEvaluationModal: (state) => {
       state.evaluationModal = false;
+      unlockBodyScroll();
     },
     setOpenModal: (state, action) => {
       state.modalType = action.payload;
+      lockBodyScroll();
     },
     setCloseModal: (state) => {
       state.modalType = "";
+      unlockBodyScroll();
     },
     /* 게시판 읽기 모달 */
     setOpenReadingModal: (state) => {
       state.readingModal = true;
+      lockBodyScroll();
     },
     setCloseReadingModal: (state) => {
       state.readingModal = false;
+      unlockBodyScroll();
     },
     /* 게시판 쓰기 모달 */
     setOpenPostingModal: (state) => {
       state.postingModal = true;
+      lockBodyScroll();
     },
     setClosePostingModal: (state) => {
       state.postingModal = false;
+      unlockBodyScroll();
     },
   },
 });

--- a/src/utils/bodyScrollLock.tsx
+++ b/src/utils/bodyScrollLock.tsx
@@ -1,0 +1,7 @@
+export const lockBodyScroll = () => {
+  document.body.style.overflow = "hidden";
+};
+
+export const unlockBodyScroll = () => {
+  document.body.style.overflow = "unset";
+};

--- a/src/utils/bodyScrollLock.tsx
+++ b/src/utils/bodyScrollLock.tsx
@@ -1,7 +1,0 @@
-export const lockBodyScroll = () => {
-  document.body.style.overflow = "hidden";
-};
-
-export const unlockBodyScroll = () => {
-  document.body.style.overflow = "unset";
-};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,4 +6,4 @@ export * from "./storage";
 export * from "./string";
 export * from "./timeFormat";
 export * from "./matching";
-export * from "./bodyScrollLock";
+export * from "./modalHelper";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from "./storage";
 export * from "./string";
 export * from "./timeFormat";
 export * from "./matching";
+export * from "./bodyScrollLock";

--- a/src/utils/modalHelper.tsx
+++ b/src/utils/modalHelper.tsx
@@ -1,10 +1,10 @@
 import { type ModalState } from "@/redux/slices/modalSlice";
 
-const lockBodyScroll = () => {
+export const lockBodyScroll = () => {
   document.body.style.overflow = "hidden";
 };
 
-const unlockBodyScroll = () => {
+export const unlockBodyScroll = () => {
   document.body.style.overflow = "unset";
 };
 

--- a/src/utils/modalHelper.tsx
+++ b/src/utils/modalHelper.tsx
@@ -1,0 +1,23 @@
+import { type ModalState } from "@/redux/slices/modalSlice";
+
+const lockBodyScroll = () => {
+  document.body.style.overflow = "hidden";
+};
+
+const unlockBodyScroll = () => {
+  document.body.style.overflow = "unset";
+};
+
+export function incrementModalCount(state: ModalState) {
+  state.openCount += 1;
+  if (state.openCount === 1) {
+    lockBodyScroll();
+  }
+}
+
+export function decrementModalCount(state: ModalState) {
+  state.openCount = Math.max(state.openCount - 1, 0);
+  if (state.openCount === 0) {
+    unlockBodyScroll();
+  }
+}


### PR DESCRIPTION
## 연관 이슈

close #318 

<br/>

## 📁 작업 내용

~~해당 일감이 양이  꽤 많을 것 같아 나눠서 PR 올리겠습니다!~~
작업 완료 했습니다!

1. 우선 `Alert` 컴포넌트를 `modal-root`에 위치할 수 있게 `createPortal`로 작업하였습니다.
2. `Alert` 컴포넌트가 기존에는 각 컴포넌트마다 렌더링되고 있었는데, 리덕스로 상태를 관리하고 컴포넌트도 그 상태에 따라 한 번만 보여질 수 있게 작업했어요.
2-1. `ConfirmModal`과 함께 `Alert `컴포넌트는 `ModalContainer`에 담겨져서 최상위 `Container`와 같은 위치에 있게 수정했어요.
3. `modalSlice.ts`에서는 모달 중첩 상황을 고려해 `modalHelper.tsx`를 만들어, 모달 개수를 관리하고 모든 모달이 닫혔을 때 `body` 스크롤을 해제하도록 구현했습니다.
4. 그렇게 해서 기존에 `alert` 컴포넌트들이 페이지마다, 컴포넌트마다 있었던 것들은 삭제하고` alert`의 `props`는 s`etOpenAlertModal`로 `alert` 모달을 열 때 설정할 수 있게 해두었습니다.


<br/>

## 🖥 구현 결과 (선택)

![무제](https://github.com/user-attachments/assets/bf8150d2-8a74-4551-aea4-0a943c8278a8)

![화면 기록 2025-07-11 오후 6 32 12](https://github.com/user-attachments/assets/830aaa07-df48-4ae4-8f34-5cdcd3e5b7df)
![화면 기록 2025-07-11 오후 11 35 39](https://github.com/user-attachments/assets/1658d3a5-ccae-4ceb-9d8d-27e725a289f2)


<br/>

## ✔ 리뷰 요구사항


<br/>

## 📁 기타 사항

- 기존에 modal상태를 리덕스로 관리하고 있어서 참고해서 만들어봤는데, 혹시 더 좋은 방법이 있다면 알려주시면 감사하겠습니다!
큰 이슈 없다면 이대로 진행하고자 합니다!

- (디코에도 적었던 내용) 작업 중 고민이 되는 부분이 있습니다!  모달이나 팝업을 전역적으로 관리하기 위해  리팩토링 하고 있습니다. 우선 Alert 컴포넌트와 리덕스로 모달 관리되고 있던 게시판 수정, 상세 , 작성하기 모달은 리덕스로 리팩토링을 한 상태인데요, ConfirmModal도 리덕스로 관리하려고 리팩토링 하던 중에 onPrimaryClick, onSecondaryClick 함수를 props로 받는 걸 확인했어요. 리덕스로 함수는 전달될 수 없어서 대체재로 thunk로 함수 키값만을 저장해서 각 컴포넌트마다 다른 함수를 넘길수는 있다고 하는 방법을 찾았지만,  연속적으로 ConfirmModal을 두 번 띄워야 하는 경우도 있어서 ConfirmModal은 context로 관리하는게 용이하려나 하는 생각이 듭니다. 그렇지만 공통 모달인데 어떤 건 Redux로 관리하고 어떤 건 context로 관리하면 좀 복잡할 것 같고 깔끔하게 한 가지 방법으로 통일되게 관리하면 좋을 것 같아서 계속 고민해보고 있는데, 딱 이렇다 할 해결책이 잘 안 떠오르네요. 🥲  혹시나 조언을 좀 얻을 수 있을까요?

<br/>
