### PR TITLE
[Design] 모바일 게시글 로딩 시 스켈레톤 UI 적용 및 Table 컴포넌트 분리

### DIFF
--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -611,7 +611,10 @@ const BoardPage = () => {
                   />
                 </ThirdRow>
                 <Main>
-                    <PostList content={boardList} isLoading={isLoading}></PostList>
+                  <PostList
+                    content={boardList}
+                    isLoading={isLoading}
+                  ></PostList>
                 </Main>
                 <div ref={sentinelRef}></div>
                 {/* IntersectionObserver 를 위한 감지용 element */}

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -611,7 +611,7 @@ const BoardPage = () => {
                   />
                 </ThirdRow>
                 <Main>
-                  <PostList content={boardList}></PostList>
+                    <PostList content={boardList} isLoading={isLoading}></PostList>
                 </Main>
                 <div ref={sentinelRef}></div>
                 {/* IntersectionObserver 를 위한 감지용 element */}

--- a/src/app/match/profile/page.tsx
+++ b/src/app/match/profile/page.tsx
@@ -6,7 +6,14 @@ import { useRouter, useSearchParams } from "next/navigation";
 import styled from "styled-components";
 
 import { getMyProfile } from "@/api";
-import { Button, ConfirmModal, HeaderTitle, Profile } from "@/components";
+import {
+  Button,
+  ConfirmModal,
+  HeaderTitle,
+  LoadingSpinner,
+  Profile,
+} from "@/components";
+import { SkeletonBox } from "@/components/common/Skeleton";
 import { useMediaQueryContext } from "@/hooks";
 import { closeChatRoom } from "@/redux/slices/chatSlice";
 import { setUserProfile } from "@/redux/slices/userSlice";
@@ -213,7 +220,11 @@ const ProfilePage = () => {
               backgroundColor={theme.colors.violet100}
             />
           ) : (
-            <p>Loading...</p>
+            <SkeletonBox
+              width="100%"
+              height={!isMobile ? "615px" : "400px"}
+              borderRadius={!isMobile ? "30px" : "8px"}
+            />
           )}
           <Button
             buttonType="primary"
@@ -241,7 +252,7 @@ const ProfilePage = () => {
 
 export default function ProfilePaging() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<LoadingSpinner />}>
       <ProfilePage />
     </Suspense>
   );

--- a/src/app/matching/complete/page.tsx
+++ b/src/app/matching/complete/page.tsx
@@ -469,7 +469,7 @@ const Complete = () => {
 
 export default function CompletePaging() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<LoadingSpinner />}>
       <Complete />
     </Suspense>
   );

--- a/src/app/matching/progress/page.tsx
+++ b/src/app/matching/progress/page.tsx
@@ -9,6 +9,7 @@ import { getBoardList } from "@/api";
 import {
   ConfirmModal,
   HeaderTitle,
+  LoadingSpinner,
   SquareProfile,
   WaitingBox,
 } from "@/components";
@@ -465,7 +466,7 @@ const Progress = () => {
 
 export default function ProgressPaging() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<LoadingSpinner />}>
       <Progress />
     </Suspense>
   );

--- a/src/components/board/PostList.tsx
+++ b/src/components/board/PostList.tsx
@@ -11,6 +11,7 @@ import {
 import { theme } from "@/styles/theme";
 
 import { PostItem } from "../common";
+import SkeletonPostItem from "../common/PostItem/SkeletonPostItem";
 
 import type { RootState } from "@/redux/store";
 import type { AlertProps } from "@/types";
@@ -18,9 +19,10 @@ import type { BoardListDetail } from "@/types/api";
 
 interface PostListProps {
   content: BoardListDetail[];
+  isLoading?: boolean;
 }
 
-const PostList = ({ content }: PostListProps) => {
+const PostList = ({ content, isLoading = false }: PostListProps) => {
   const dispatch = useDispatch();
   const router = useRouter();
 
@@ -92,7 +94,11 @@ const PostList = ({ content }: PostListProps) => {
 
       {isChatRoomOpen && <Layout />}
       <ListWrapper>
-        {content?.length > 0 ? (
+        {isLoading ? (
+          Array.from({ length: 3 }).map((_, index) => (
+            <SkeletonPostItem key={index} />
+          ))
+        ) : content?.length > 0 ? (
           content.map((data) => (
             <PostItem
               key={data.boardId}

--- a/src/components/board/Table.tsx
+++ b/src/components/board/Table.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 
@@ -16,11 +15,8 @@ import {
 } from "@/api";
 import {
   Alert,
-  Champion,
   ConfirmModal,
   Layout,
-  MoreBox,
-  MoreBoxButton,
   ReadBoard,
   ReportModal,
 } from "@/components";
@@ -34,16 +30,11 @@ import {
   setOpenPostingModal,
   setOpenReadingModal,
 } from "@/redux/slices/modalSlice";
-import { setCurrentPost, setPostStatus } from "@/redux/slices/postSlice";
+import { setPostStatus } from "@/redux/slices/postSlice";
 import { theme } from "@/styles/theme";
-import {
-  setAbbrevTier,
-  setCustomProfileImg,
-  setPositionImg,
-} from "@/utils/custom";
-import { getProfileBgColor } from "@/utils/profile";
-import { toLowerCaseString } from "@/utils/string";
-import { setDateFormatter } from "@/utils/timeFormat";
+
+import TableHead from "./Table/TableHead";
+import TableRow from "./Table/TableRow";
 
 import type { RootState } from "@/redux/store";
 import type {
@@ -52,11 +43,7 @@ import type {
   MemberPost,
   MoreBoxMenuItems,
 } from "@/types";
-
-interface TableTitleProps {
-  id: number;
-  name: string;
-}
+import type { TableTitleProps } from "@/types/board/table";
 
 interface TableProps {
   title: TableTitleProps[];
@@ -400,144 +387,24 @@ const Table = (props: TableProps) => {
 
       {copiedAlert && <Copied>소환사명이 클립보드에 복사되었습니다.</Copied>}
       <TableWrapper>
-        <TableHead>
-          {title.map((data) => {
-            return (
-              <Title key={data.id} className="table_width">
-                {data.name}
-              </Title>
-            );
-          })}
-        </TableHead>
+        <TableHead title={title} />
         {content?.length > 0 ? (
           <TableContent>
-            {content?.map((data) => {
-              return (
-                <Row
-                  key={data.boardId}
-                  onClick={() => {
-                    setIsMoreBoxOpen(false);
-                    handlePostOpen(data.boardId);
-                  }}
-                >
-                  <First className="table_width">
-                    <ProfileImgWrapper
-                      $bgColor={getProfileBgColor(data.profileImage)}
-                      onClick={(e) => handleMoveProfilePage(e, data.memberId)}
-                    >
-                      <ProfileImg
-                        data={setCustomProfileImg(data.profileImage)}
-                        width={35}
-                        height={35}
-                      />
-                    </ProfileImgWrapper>
-                    <NameRow>
-                      <P>{data.gameName}</P>
-                      <CopyButton
-                        onClick={(e) =>
-                          handleTextClick(data.gameName, data.tag, e)
-                        }
-                      >
-                        복사
-                      </CopyButton>
-                    </NameRow>
-                  </First>
-                  <Second className="table_width">
-                    {data.mannerLevel && <p>LV.{data.mannerLevel}</p>}
-                  </Second>
-                  <Third className="table_width">
-                    <TierImage
-                      data={
-                        !data.tier
-                          ? "/assets/images/tier/unranked.svg"
-                          : `/assets/images/tier/${toLowerCaseString(
-                              data.tier
-                            )}.svg`
-                      }
-                      width={28}
-                      height={26}
-                    />
-                    <P>
-                      {setAbbrevTier(data.tier || "")}
-                      {data.tier !== "UNRANKED" && data.rank}
-                    </P>
-                  </Third>
-                  <Fourth className="table_width">
-                    <Image
-                      src={setPositionImg(data.mainP)}
-                      width={36}
-                      height={36}
-                      alt="메인 포지션"
-                    />
-                    <Image
-                      src={setPositionImg(data.subP)}
-                      width={36}
-                      height={36}
-                      alt="서브 포지션"
-                    />
-                  </Fourth>
-                  <Fifth className="table_width">
-                    {data.wantP?.length > 0 ? (
-                      data.wantP.map((posi, i) => (
-                        <Image
-                          key={`${posi}-${i}`}
-                          src={setPositionImg(posi || "ANY")}
-                          width={36}
-                          height={36}
-                          alt="찾는 포지션"
-                        />
-                      ))
-                    ) : (
-                      <Image
-                        src={setPositionImg("ANY")}
-                        width={35}
-                        height={28}
-                        alt="찾는 포지션"
-                      />
-                    )}
-                  </Fifth>
-                  <Sixth className="table_width">
-                    <Champion
-                      font="semiBold14"
-                      list={data?.championStatsResponseList || []}
-                    />
-                  </Sixth>
-                  <Seventh className="table_width">
-                    <P className={data.winRate >= 50 ? "emph" : "basic"}>
-                      {data.winRate === null ? "0%" : `${data.winRate}%`}
-                    </P>
-                  </Seventh>
-                  <Eighth className="table_width">
-                    <Content>{data.contents}</Content>
-                  </Eighth>
-                  <Ninth className="table_width">
-                    <P className="gray">
-                      {setDateFormatter(data.bumpTime || data.createdAt)}
-                    </P>
-                    {isUser.id ? (
-                      <More>
-                        <MoreBoxButton
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleMoreBoxToggle(data.boardId);
-                          }}
-                        />
-                        {isMoreBoxOpen && isBoardId === data.boardId && (
-                          <MoreBox
-                            items={MoreBoxMenuItems}
-                            top={0}
-                            left={-180}
-                            onClose={(e: any) => {
-                              setIsMoreBoxOpen(false);
-                            }}
-                          />
-                        )}
-                      </More>
-                    ) : null}
-                  </Ninth>
-                </Row>
-              );
-            })}
+            {content?.map((data) => (
+              <TableRow
+                key={data.boardId}
+                data={data}
+                isUser={isUser}
+                isBoardId={isBoardId}
+                isMoreBoxOpen={isMoreBoxOpen}
+                onRowClick={handlePostOpen}
+                onMoveProfile={handleMoveProfilePage}
+                onCopyText={handleTextClick}
+                onMoreBoxToggle={handleMoreBoxToggle}
+                onMoreBoxClose={handleMoreBoxClose}
+                menuItems={MoreBoxMenuItems}
+              />
+            ))}
           </TableContent>
         ) : (
           <NoData>게시된 글이 없습니다.</NoData>
@@ -650,179 +517,7 @@ const TableWrapper = styled.div`
   }
 `;
 
-const TableHead = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 21px;
-  ${(props) => props.theme.fonts.bold14};
-  background: ${theme.colors.gray700};
-  color: ${theme.colors.white};
-  border-radius: 8px;
-`;
-
-const Title = styled.p`
-  &:first-child {
-    text-align: left;
-  }
-`;
-
 const TableContent = styled.div``;
-
-const Row = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 22px 21px;
-  border-bottom: 1px solid #d4d4d4;
-  cursor: pointer;
-`;
-
-const First = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`;
-
-const Second = styled.div`
-  p {
-    color: ${theme.colors.violet600};
-    ${(props) => props.theme.fonts.bold16};
-  }
-`;
-
-const ProfileImgWrapper = styled.div<{ $bgColor: string }>`
-  position: relative;
-  width: 50px;
-  height: 50px;
-  background: ${(props) => props.$bgColor};
-  border-radius: 50%;
-  aspect-ratio: 1;
-`;
-
-const ProfileImg = styled.object`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  pointer-events: none;
-`;
-
-const Third = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 3px;
-`;
-
-const TierImage = styled.object`
-  pointer-events: none;
-`;
-
-const Fourth = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 21px;
-`;
-
-const Fifth = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-
-const Sixth = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 5px;
-`;
-
-const Seventh = styled.div``;
-
-const Eighth = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-
-const Ninth = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  p {
-    width: 60px;
-  }
-`;
-
-const More = styled.div`
-  position: relative;
-`;
-
-const NameRow = styled.div`
-  display: flex;
-  align-items: center;
-  position: relative;
-
-  &:hover > button {
-    display: inline-flex;
-  }
-`;
-
-const P = styled.p`
-  ${(props) => props.theme.fonts.medium16};
-  color: ${theme.colors.gray800};
-  white-space: nowrap;
-  &.emph {
-    color: ${theme.colors.violet600};
-    ${(props) => props.theme.fonts.bold16};
-  }
-  &.gray {
-    color: ${theme.colors.gray500};
-    ${(props) => props.theme.fonts.medium16};
-  }
-`;
-
-const Content = styled.div`
-  display: -webkit-box;
-  width: 156px;
-  max-height: 52px;
-  padding: 8px;
-  text-align: center;
-  border-radius: 8px;
-  border: 1px solid ${theme.colors.gray400};
-  background: ${theme.colors.gray100};
-  color: ${theme.colors.gray700};
-  ${(props) => props.theme.fonts.regular13};
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
-const CopyButton = styled.button`
-  width: auto;
-  height: 20px;
-  margin-left: 10px;
-  border-radius: 2px;
-  padding: 0px 7px;
-  background: ${theme.colors.gray600};
-  color: ${theme.colors.white};
-  ${theme.fonts.medium11};
-  line-height: 11px;
-  white-space: nowrap;
-
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  display: none;
-  &:hover {
-    color: ${theme.colors.violet300};
-  }
-`;
 
 const NoData = styled.p`
   color: ${theme.colors.gray800};

--- a/src/components/board/Table/TableHead.tsx
+++ b/src/components/board/Table/TableHead.tsx
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+
+import type { TableTitleProps } from "@/types/board/table";
+
+interface TableHeadProps {
+  title: TableTitleProps[];
+}
+
+const TableHead = ({ title }: TableHeadProps) => {
+  return (
+    <Wrapper>
+      {title.map((data) => (
+        <Title key={data.id} className="table_width">
+          {data.name}
+        </Title>
+      ))}
+    </Wrapper>
+  );
+};
+
+export default TableHead;
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 21px;
+  ${(props) => props.theme.fonts.bold14};
+  background: ${(props) => props.theme.colors.gray700};
+  color: ${(props) => props.theme.colors.white};
+  border-radius: 8px;
+`;
+
+const Title = styled.p`
+  &:first-child {
+    text-align: left;
+  }
+`;

--- a/src/components/board/Table/TableRow.tsx
+++ b/src/components/board/Table/TableRow.tsx
@@ -1,0 +1,81 @@
+import styled from "styled-components";
+
+import { ChampionCell } from "./cells/ChampionCell";
+import { ContentCell } from "./cells/ContentCell";
+import { MannerLevelCell } from "./cells/MannerLevelCell";
+import { MoreCell } from "./cells/MoreCell";
+import { PositionCell } from "./cells/PositionCell";
+import ProfileCell from "./cells/ProfileCell";
+import { TierCell } from "./cells/TierCell";
+import { WantPositionCell } from "./cells/WantPositionCell";
+import { WinRateCell } from "./cells/WinRateCell";
+
+import type { BoardListDetail, MoreBoxMenuItems, User } from "@/types";
+
+interface TableRowProps {
+  data: BoardListDetail;
+  isUser: User;
+  isBoardId: number;
+  isMoreBoxOpen: boolean;
+  onRowClick: (boardId: number) => void;
+  onMoveProfile: (e: React.MouseEvent, memberId: number) => void;
+  onCopyText: (gameName: string, tag: string, e: React.MouseEvent) => void;
+  onMoreBoxToggle: (boardId: number) => void;
+  onMoreBoxClose: () => void;
+  menuItems: MoreBoxMenuItems[];
+}
+
+const TableRow = ({
+  data,
+  isUser,
+  isBoardId,
+  isMoreBoxOpen,
+  onRowClick,
+  onMoveProfile,
+  onCopyText,
+  onMoreBoxToggle,
+  onMoreBoxClose,
+  menuItems,
+}: TableRowProps) => {
+  return (
+    <Row onClick={() => onRowClick(data.boardId)}>
+      <ProfileCell
+        gameName={data.gameName}
+        tag={data.tag}
+        memberId={data.memberId}
+        profileImageId={data.profileImage}
+        onMoveProfile={onMoveProfile}
+        onCopyText={onCopyText}
+      />
+      <MannerLevelCell mannerLevel={data.mannerLevel} />
+      <TierCell tier={data.tier} rank={data.rank} />
+      <PositionCell mainP={data.mainP} subP={data.subP} />
+      <WantPositionCell wantP={data.wantP || []} />
+      <ChampionCell champions={data.championStatsResponseList || []} />
+      <WinRateCell winRate={data.winRate} />
+      <ContentCell contents={data.contents} />
+      <MoreCell
+        isUserId={isUser.id || 0}
+        boardId={data.boardId}
+        isMoreBoxOpen={isMoreBoxOpen}
+        isBoardId={isBoardId}
+        bumpTime={data.bumpTime}
+        createdAt={data.createdAt}
+        onMoreBoxToggle={onMoreBoxToggle}
+        onMoreBoxClose={onMoreBoxClose}
+        menuItems={menuItems}
+      />
+    </Row>
+  );
+};
+
+export default TableRow;
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 22px 21px;
+  border-bottom: 1px solid #d4d4d4;
+  cursor: pointer;
+`;

--- a/src/components/board/Table/cells/ChampionCell.tsx
+++ b/src/components/board/Table/cells/ChampionCell.tsx
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+import { Champion } from "@/components/common";
+
+export const ChampionCell = ({ champions }: { champions: any[] }) => (
+  <Sixth className="table_width">
+    <Champion font="semiBold14" list={champions || []} />
+  </Sixth>
+);
+
+const Sixth = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+`;

--- a/src/components/board/Table/cells/ContentCell.tsx
+++ b/src/components/board/Table/cells/ContentCell.tsx
@@ -1,0 +1,32 @@
+import styled from "styled-components";
+
+import { theme } from "@/styles/theme";
+
+export const ContentCell = ({ contents }: { contents: string }) => (
+  <Eighth className="table_width">
+    <Content>{contents}</Content>
+  </Eighth>
+);
+
+const Eighth = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Content = styled.div`
+  display: -webkit-box;
+  width: 156px;
+  max-height: 52px;
+  padding: 8px;
+  text-align: center;
+  border-radius: 8px;
+  border: 1px solid ${theme.colors.gray400};
+  background: ${theme.colors.gray100};
+  color: ${theme.colors.gray700};
+  ${(props) => props.theme.fonts.regular13};
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/src/components/board/Table/cells/MannerLevelCell.tsx
+++ b/src/components/board/Table/cells/MannerLevelCell.tsx
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+import { theme } from "@/styles/theme";
+
+export const MannerLevelCell = ({ mannerLevel }: { mannerLevel?: number }) => (
+  <Second className="table_width">
+    {mannerLevel && <p>LV.{mannerLevel}</p>}
+  </Second>
+);
+
+const Second = styled.div`
+  p {
+    color: ${theme.colors.violet600};
+    ${(props) => props.theme.fonts.bold16};
+  }
+`;

--- a/src/components/board/Table/cells/MoreCell.tsx
+++ b/src/components/board/Table/cells/MoreCell.tsx
@@ -1,0 +1,78 @@
+import styled from "styled-components";
+
+import { MoreBox } from "@/components/common";
+import { MoreBoxButton } from "@/components/readBoard";
+import { theme } from "@/styles/theme";
+import { setDateFormatter } from "@/utils";
+
+export const MoreCell = ({
+  bumpTime,
+  createdAt,
+  isUserId,
+  isBoardId,
+  boardId,
+  isMoreBoxOpen,
+  onMoreBoxToggle,
+  onMoreBoxClose,
+  menuItems,
+}: {
+  bumpTime: string;
+  createdAt: string;
+  isUserId: number;
+  isBoardId: number;
+  boardId: number;
+  isMoreBoxOpen: boolean;
+  onMoreBoxToggle: (boardId: number) => void;
+  onMoreBoxClose: () => void;
+  menuItems: any[];
+}) => (
+  <Ninth className="table_width">
+    <P className="gray">{setDateFormatter(bumpTime || createdAt)}</P>
+    {isUserId && (
+      <More>
+        <MoreBoxButton
+          onClick={(e) => {
+            e.stopPropagation();
+            onMoreBoxToggle(boardId);
+          }}
+        />
+        {isMoreBoxOpen && isBoardId === boardId && (
+          <MoreBox
+            items={menuItems}
+            top={0}
+            left={-180}
+            onClose={onMoreBoxClose}
+          />
+        )}
+      </More>
+    )}
+  </Ninth>
+);
+
+const Ninth = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  p {
+    width: 60px;
+  }
+`;
+
+const More = styled.div`
+  position: relative;
+`;
+
+const P = styled.p`
+  ${(props) => props.theme.fonts.medium16};
+  color: ${theme.colors.gray800};
+  white-space: nowrap;
+  &.emph {
+    color: ${theme.colors.violet600};
+    ${(props) => props.theme.fonts.bold16};
+  }
+  &.gray {
+    color: ${theme.colors.gray500};
+    ${(props) => props.theme.fonts.medium16};
+  }
+`;

--- a/src/components/board/Table/cells/PositionCell.tsx
+++ b/src/components/board/Table/cells/PositionCell.tsx
@@ -1,0 +1,36 @@
+import Image from "next/image";
+import styled from "styled-components";
+
+import { setPositionImg } from "@/utils";
+
+import type { Position } from "@/types";
+
+export const PositionCell = ({
+  mainP,
+  subP,
+}: {
+  mainP: Position;
+  subP: Position;
+}) => (
+  <Fourth className="table_width">
+    <Image
+      src={setPositionImg(mainP)}
+      width={36}
+      height={36}
+      alt="메인 포지션"
+    />
+    <Image
+      src={setPositionImg(subP)}
+      width={36}
+      height={36}
+      alt="서브 포지션"
+    />
+  </Fourth>
+);
+
+const Fourth = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 21px;
+`;

--- a/src/components/board/Table/cells/ProfileCell.tsx
+++ b/src/components/board/Table/cells/ProfileCell.tsx
@@ -1,0 +1,101 @@
+import styled from "styled-components";
+
+import { setCustomProfileImg } from "@/utils/custom";
+import { getProfileBgColor } from "@/utils/profile";
+
+interface ProfileCellProps {
+  profileImageId: number;
+  gameName: string;
+  tag: string;
+  memberId: number;
+  onMoveProfile: (e: React.MouseEvent, memberId: number) => void;
+  onCopyText: (gameName: string, tag: string, e: React.MouseEvent) => void;
+}
+
+const ProfileCell = ({
+  profileImageId,
+  gameName,
+  tag,
+  memberId,
+  onMoveProfile,
+  onCopyText,
+}: ProfileCellProps) => {
+  return (
+    <Wrapper className="table_width">
+      <ProfileImgWrapper
+        $bgColor={getProfileBgColor(profileImageId)}
+        onClick={(e) => onMoveProfile(e, memberId)}
+      >
+        <ProfileImg
+          data={setCustomProfileImg(profileImageId)}
+          width={35}
+          height={35}
+        />
+      </ProfileImgWrapper>
+      <NameRow>
+        <P>{gameName}</P>
+        <CopyButton onClick={(e) => onCopyText(gameName, tag, e)}>
+          복사
+        </CopyButton>
+      </NameRow>
+    </Wrapper>
+  );
+};
+
+export default ProfileCell;
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const ProfileImgWrapper = styled.div<{ $bgColor: string }>`
+  position: relative;
+  width: 50px;
+  height: 50px;
+  background: ${(props) => props.$bgColor};
+  border-radius: 50%;
+  aspect-ratio: 1;
+`;
+
+const ProfileImg = styled.object`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+`;
+
+const NameRow = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+
+  &:hover > button {
+    display: inline-flex;
+  }
+`;
+
+const P = styled.p`
+  ${(props) => props.theme.fonts.medium16};
+  color: ${(props) => props.theme.colors.gray800};
+  white-space: nowrap;
+`;
+
+const CopyButton = styled.button`
+  width: auto;
+  height: 20px;
+  margin-left: 10px;
+  border-radius: 2px;
+  padding: 0px 7px;
+  background: ${(props) => props.theme.colors.gray600};
+  color: ${(props) => props.theme.colors.white};
+  ${(props) => props.theme.fonts.medium11};
+  line-height: 11px;
+  white-space: nowrap;
+  display: none;
+  &:hover {
+    color: ${(props) => props.theme.colors.violet300};
+  }
+`;

--- a/src/components/board/Table/cells/TierCell.tsx
+++ b/src/components/board/Table/cells/TierCell.tsx
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+
+import { theme } from "@/styles/theme";
+import { setAbbrevTier, toLowerCaseString } from "@/utils";
+
+export const TierCell = ({ tier, rank }: { tier: string; rank?: number }) => (
+  <Third className="table_width">
+    <TierImage
+      data={
+        !tier
+          ? "/assets/images/tier/unranked.svg"
+          : `/assets/images/tier/${toLowerCaseString(tier)}.svg`
+      }
+      width={28}
+      height={26}
+    />
+    <P>
+      {setAbbrevTier(tier || "")}
+      {tier !== "UNRANKED" && rank}
+    </P>
+  </Third>
+);
+
+const Third = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+`;
+
+const TierImage = styled.object`
+  pointer-events: none;
+`;
+
+const P = styled.p`
+  ${(props) => props.theme.fonts.medium16};
+  color: ${theme.colors.gray800};
+  white-space: nowrap;
+  &.emph {
+    color: ${theme.colors.violet600};
+    ${(props) => props.theme.fonts.bold16};
+  }
+  &.gray {
+    color: ${theme.colors.gray500};
+    ${(props) => props.theme.fonts.medium16};
+  }
+`;

--- a/src/components/board/Table/cells/WantPositionCell.tsx
+++ b/src/components/board/Table/cells/WantPositionCell.tsx
@@ -1,0 +1,35 @@
+import Image from "next/image";
+import styled from "styled-components";
+
+import { setPositionImg } from "@/utils";
+
+import type { Position } from "@/types";
+
+export const WantPositionCell = ({ wantP }: { wantP: (Position | null)[] }) => (
+  <Fifth className="table_width">
+    {wantP?.length > 0 ? (
+      wantP.map((posi, i) => (
+        <Image
+          key={`${posi}-${i}`}
+          src={setPositionImg(posi || "ANY")}
+          width={36}
+          height={36}
+          alt="찾는 포지션"
+        />
+      ))
+    ) : (
+      <Image
+        src={setPositionImg("ANY")}
+        width={35}
+        height={28}
+        alt="찾는 포지션"
+      />
+    )}
+  </Fifth>
+);
+
+const Fifth = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/components/board/Table/cells/WinRateCell.tsx
+++ b/src/components/board/Table/cells/WinRateCell.tsx
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+import { theme } from "@/styles/theme";
+
+export const WinRateCell = ({ winRate }: { winRate: number | null }) => (
+  <Seventh className="table_width">
+    <P className={winRate && winRate >= 50 ? "emph" : "basic"}>
+      {winRate === null ? "0%" : `${winRate}%`}
+    </P>
+  </Seventh>
+);
+
+const Seventh = styled.div``;
+
+const P = styled.p`
+  ${(props) => props.theme.fonts.medium16};
+  color: ${theme.colors.gray800};
+  white-space: nowrap;
+  &.emph {
+    color: ${theme.colors.violet600};
+    ${(props) => props.theme.fonts.bold16};
+  }
+  &.gray {
+    color: ${theme.colors.gray500};
+    ${(props) => props.theme.fonts.medium16};
+  }
+`;

--- a/src/components/common/PostItem/SkeletonPostItem.tsx
+++ b/src/components/common/PostItem/SkeletonPostItem.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import styled from "styled-components";
+
+import { SkeletonCircle, SkeletonText } from "@/components/common/Skeleton";
+import { theme } from "@/styles/theme";
+
+const SkeletonPostItem: React.FC = () => {
+  return (
+    <SkeletonCard>
+      <ProfileRow>
+        <SkeletonCircle width="44px" height="44px" />
+        <div style={{ flex: 1 }}>
+          <SkeletonText width="40%" height="24px" marginBottom="3px" />
+          <SkeletonText width="10%" height="15px" />
+        </div>
+      </ProfileRow>
+
+      <InfoRow>
+        <SkeletonText width="100%" height="30px" />
+        <SkeletonText width="100%" height="30px" />
+      </InfoRow>
+
+      <InfoRow>
+        <SkeletonText width="100%" height="70px" />
+        <SkeletonText width="100%" height="70px" />
+      </InfoRow>
+
+      <InfoRow>
+        <ChampionRow>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <SkeletonCircle key={index} width="45px" height="45px" />
+          ))}
+        </ChampionRow>
+        <SkeletonText width="50%" height="45px" />
+      </InfoRow>
+
+      <ContentBox>
+        <SkeletonText width="100%" height="52px" />
+      </ContentBox>
+    </SkeletonCard>
+  );
+};
+
+export default SkeletonPostItem;
+
+const SkeletonCard = styled.div`
+  width: 100%;
+  height: 353px;
+  background: ${theme.colors.white};
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const ProfileRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+/* 티어, 포지션, 승률 영역 */
+const InfoRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+`;
+
+const ChampionRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6.5px;
+`;
+
+const ContentBox = styled.div`
+  width: 100%;
+  height: 50px;
+`;

--- a/src/components/common/Skeleton.tsx
+++ b/src/components/common/Skeleton.tsx
@@ -1,0 +1,47 @@
+import styled, { keyframes } from "styled-components";
+
+interface SkeletonProps {
+  width?: string;
+  height?: string;
+  marginBottom?: string;
+  borderRadius?: string;
+}
+
+const shimmer = keyframes`
+  0% {
+    background-position: -200px 0;
+  }
+  100% {
+    background-position: calc(200px + 100%) 0;
+  }
+`;
+
+const SkeletonWrapper = styled.div`
+  background: #e0e0e0;
+  background-image: linear-gradient(
+    90deg,
+    #e0e0e0 25%,
+    #f0f0f0 50%,
+    #e0e0e0 75%
+  );
+  background-size: 400px 100%;
+  animation: ${shimmer} 0.8s infinite linear;
+  border-radius: 5px;
+`;
+
+export const SkeletonBox = styled(SkeletonWrapper)<SkeletonProps>`
+  width: ${(props) => props.width || "100%"};
+  height: ${(props) => props.height || "100px"};
+`;
+
+export const SkeletonCircle = styled(SkeletonWrapper)<SkeletonProps>`
+  width: ${(props) => props.width || "50px"};
+  height: ${(props) => props.height || "50px"};
+  border-radius: ${(props) => props.borderRadius || "50%"};
+`;
+
+export const SkeletonText = styled(SkeletonWrapper)<SkeletonProps>`
+  width: ${(props) => props.width || "100%"};
+  height: ${(props) => props.height || "20px"};
+  margin-bottom: ${(props) => props.marginBottom || "0px"};
+`;

--- a/src/components/common/Skeleton.tsx
+++ b/src/components/common/Skeleton.tsx
@@ -32,6 +32,7 @@ const SkeletonWrapper = styled.div`
 export const SkeletonBox = styled(SkeletonWrapper)<SkeletonProps>`
   width: ${(props) => props.width || "100%"};
   height: ${(props) => props.height || "100px"};
+  border-radius: ${(props) => props.borderRadius || "5px"};
 `;
 
 export const SkeletonCircle = styled(SkeletonWrapper)<SkeletonProps>`

--- a/src/components/mypage/post/MoPost.tsx
+++ b/src/components/mypage/post/MoPost.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/navigation";
 import { getMemberPost, getNonMemberPost } from "@/api";
 import { Alert, PostItem } from "@/components/common";
 
+import SkeletonPostItem from "../../common/PostItem/SkeletonPostItem";
+
 import type { AxiosError } from "axios";
 import type { PostItemData } from "@/components/common";
 import type { RootState } from "@/redux/store";
@@ -145,7 +147,7 @@ const MoPost: React.FC<PostProps> = ({
   };
 
   if (loading) {
-    return <div>Loading...</div>;
+    return <SkeletonPostItem />;
   }
 
   return (

--- a/src/types/board/table.d.ts
+++ b/src/types/board/table.d.ts
@@ -1,0 +1,4 @@
+export interface TableTitleProps {
+  id: number;
+  name: string;
+}


### PR DESCRIPTION
## 연관 이슈

close #304

<br/>

## 📁 작업 내용
- `Skeleton.tsx` 컴포넌트 제작
- 모바일 게시글 로딩 시 스켈레톤 UI 적용 (게시글, 내가 작성한 글)
- fallback "Loading..." string으로 된 것들 `LoadingSpinner`로 변경
- Table 컴포넌트 하위요소 분리 (`/components/board/Table/cells`) 

<br/>

## 🖥 구현 결과 (선택)
- 기존 오류

https://github.com/user-attachments/assets/111aeedc-604b-4821-99b9-fb020bf01439



- 수정 후

![화면 캡처 2025-07-12 022708](https://github.com/user-attachments/assets/e7c944be-8bb1-4c6a-8ae4-f03d4cf829d4)

<br/>

## ✔ 리뷰 요구사항
- `Table` 컴포넌트 분리 시 폴더 구조로 `PostItem`을 참고했습니다. 근데, 궁금했던 게 PostItem이 `/common` 보다는 `/board` 하위에 있는게 자연스럽다고 느꼈는데 별도의 기준이 있으셨는지 궁금합니다! 그리고 PostItem처럼 폴더명 첫글자를 대문자로 하신 이유는 PostItem 컴포넌트를 쪼갠 컴포넌트가 담겨있기 때문으로 이해했는데, 그 하위도 계속해서 대문자로 시작하는 이유가 궁금합니다. 저도 비슷하게 Table 하위에 cells 폴더를 두었는데 여기서 Cells로 해야하나, cells로 해야하나 고민을 했어서 같이 기준을 만들면 좋을 것 같아요! (@42sungwook )
- Skeleton 로딩 시에 게시글 개수만큼 요소가 보이면 좋겠는데, 데이터가 들어오기 전 로딩 상태에서는 개수조차 알 수 없더라구요. 그래서 임의로 3개 정도 요소가 미리보기 되게 했습니다. 모바일이기도 하고 정보가 로드되면 상단으로 스크롤이 올라와, 기능상은 괜찮을 것 같긴 한데 원래 스켈레톤을 이렇게 갯수를 임의로 정해서 보여주기도 하는지 잘 모르겠어 리뷰 요청드립니다!
<br/>

## 📁 기타 사항
- Skeleton은 기본 모양 정도만 두었는데 필요시 조합해서 사용하시면 되시고 다른 모양 등 새로운 요소도 추가하셔도 됩니다! 모바일에서는 로딩 상태가 눈에 띄어서 설정했는데 데스크탑 뷰에서는 우선 필요성이 느껴지지 않아 적용하지 않았습니다. 게시판 데스크탑 뷰에서는 만약 필요하다면 로딩 스피너도 괜찮을 것 같은데 보시고 의견 남겨주세요!

<br/>
