### PR TITLE
[Refactor] Profile 컴포넌트 분리 리팩토링

### DIFF
--- a/src/app/matching/progress/page.tsx
+++ b/src/app/matching/progress/page.tsx
@@ -329,9 +329,10 @@ const Progress = () => {
           page: 1,
           pageIdx: 1,
           gameMode: gameRank as GameMode,
-          /* TODO : 기획사항에 맞게 올바른 티어 전달하기 */
-          // tier: user.tier,
-          tier: user.soloTier, // 임시로 솔로티어로 전달
+          tier: getEffectiveTier(
+            { soloTier: user.soloTier, freeTier: user.freeTier },
+            user.gameMode
+          ),
           mainP: user.mainP,
           mike: user.mike,
         };

--- a/src/components/board/Table/cells/TierCell.tsx
+++ b/src/components/board/Table/cells/TierCell.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 import { theme } from "@/styles/theme";
-import { setTierAbbr, toLowerCaseString } from "@/utils";
+import { checkTierAbbr, toLowerCaseString } from "@/utils";
 
 export const TierCell = ({ tier, rank }: { tier: string; rank?: number }) => (
   <Third className="table_width">
@@ -15,7 +15,7 @@ export const TierCell = ({ tier, rank }: { tier: string; rank?: number }) => (
       height={26}
     />
     <P>
-      {setTierAbbr(tier || "")}
+      {checkTierAbbr(tier || "")}
       {tier !== "UNRANKED" && rank}
     </P>
   </Third>

--- a/src/components/board/Table/cells/TierCell.tsx
+++ b/src/components/board/Table/cells/TierCell.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 import { theme } from "@/styles/theme";
-import { setAbbrevTier, toLowerCaseString } from "@/utils";
+import { setTierAbbr, toLowerCaseString } from "@/utils";
 
 export const TierCell = ({ tier, rank }: { tier: string; rank?: number }) => (
   <Third className="table_width">
@@ -15,7 +15,7 @@ export const TierCell = ({ tier, rank }: { tier: string; rank?: number }) => (
       height={26}
     />
     <P>
-      {setAbbrevTier(tier || "")}
+      {setTierAbbr(tier || "")}
       {tier !== "UNRANKED" && rank}
     </P>
   </Third>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -191,11 +191,7 @@ const Header = () => {
           <Menu
             selected={pathname.includes("/match")}
             onClick={() => {
-              if (!accesssToken) {
-                showLoginAlert();
-              } else {
-                router.push("/match");
-              }
+              router.push("/match");
             }}
           >
             바로 매칭

--- a/src/components/common/RankTier.tsx
+++ b/src/components/common/RankTier.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled, { css } from "styled-components";
 
 import { theme } from "@/styles/theme";
-import { setTierAbbr, toCapitalizedString, toLowerCaseString } from "@/utils";
+import { checkTierAbbr, toCapitalizedString, toLowerCaseString } from "@/utils";
 
 type RankType = "solo" | "free";
 
@@ -43,7 +43,7 @@ const RankTier = (props: RankTierProps) => {
           height={direct === "row" ? 24 : 32}
         />
         {isTierAbbr
-          ? setTierAbbr(tier) + (rank ? `${rank}` : "")
+          ? checkTierAbbr(tier) + (rank ? `${rank}` : "")
           : toCapitalizedString(tier || "UNRANK") + (rank ? ` ${rank}` : "")}
       </Tier>
     </Container>

--- a/src/components/common/RankTier.tsx
+++ b/src/components/common/RankTier.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled, { css } from "styled-components";
 
 import { theme } from "@/styles/theme";
-import { setAbbrevTier, toCapitalizedString, toLowerCaseString } from "@/utils";
+import { setTierAbbr, toCapitalizedString, toLowerCaseString } from "@/utils";
 
 type RankType = "solo" | "free";
 
@@ -14,7 +14,7 @@ interface RankTierProps {
   color?: string;
   rankFontSize?: string;
   tierFontSize?: string;
-  isAbbre?: boolean;
+  isTierAbbr?: boolean; // 티어명 축약 여부
 }
 
 const RankTier = (props: RankTierProps) => {
@@ -26,7 +26,7 @@ const RankTier = (props: RankTierProps) => {
     color,
     rankFontSize,
     tierFontSize,
-    isAbbre = false,
+    isTierAbbr = false,
   } = props;
 
   return (
@@ -42,8 +42,8 @@ const RankTier = (props: RankTierProps) => {
           width={direct === "row" ? 24 : 32}
           height={direct === "row" ? 24 : 32}
         />
-        {isAbbre
-          ? setAbbrevTier(tier) + (rank ? `${rank}` : "")
+        {isTierAbbr
+          ? setTierAbbr(tier) + (rank ? `${rank}` : "")
           : toCapitalizedString(tier || "UNRANK") + (rank ? ` ${rank}` : "")}
       </Tier>
     </Container>

--- a/src/components/match/SquareProfile.tsx
+++ b/src/components/match/SquareProfile.tsx
@@ -97,7 +97,7 @@ const SquareProfile: React.FC<SquareProfileProps> = ({
                 tier={user.soloTier}
                 rank={user.soloRank}
                 direct="row"
-                isAbbre={isMobile}
+                isTierAbbr={isMobile}
               />
               <Bar />
               <RankTier
@@ -105,7 +105,7 @@ const SquareProfile: React.FC<SquareProfileProps> = ({
                 tier={user.freeTier}
                 rank={user.freeRank}
                 direct="row"
-                isAbbre={isMobile}
+                isTierAbbr={isMobile}
               />
             </SecondRow>
           </AccountInfo>

--- a/src/components/mypage/post/Post.tsx
+++ b/src/components/mypage/post/Post.tsx
@@ -17,8 +17,8 @@ import { setUserId } from "@/redux/slices/userSlice";
 import { theme } from "@/styles/theme";
 import {
   getProfileBgColor,
-  setAbbrevTier,
   setDateFormatter,
+  setTierAbbr,
   toLowerCaseString,
 } from "@/utils";
 
@@ -150,7 +150,7 @@ const Post: React.FC<PostProps> = ({
               height={26}
             />
             <span>
-              {setAbbrevTier(tier)}
+              {setTierAbbr(tier)}
               {rank}
             </span>
           </Tier>

--- a/src/components/mypage/post/Post.tsx
+++ b/src/components/mypage/post/Post.tsx
@@ -16,9 +16,9 @@ import { setCurrentPost, setPostStatus } from "@/redux/slices/postSlice";
 import { setUserId } from "@/redux/slices/userSlice";
 import { theme } from "@/styles/theme";
 import {
+  checkTierAbbr,
   getProfileBgColor,
   setDateFormatter,
-  setTierAbbr,
   toLowerCaseString,
 } from "@/utils";
 
@@ -150,7 +150,7 @@ const Post: React.FC<PostProps> = ({
               height={26}
             />
             <span>
-              {setTierAbbr(tier)}
+              {checkTierAbbr(tier)}
               {rank}
             </span>
           </Tier>

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -710,9 +710,6 @@ const Profile: React.FC<Profile> = ({
               />
             )}
         </StyledBox>
-        {/* {isMobile &&
-          (profileType === "me" || profileType === "other") &&
-          renderFriendsButton()} */}
         {isMobile && renderFriendsButton()}
       </Row>
 

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -30,13 +30,14 @@ import GameStyle from "../match/GameStyle";
 import { useBlock } from "./Profile/hooks/useBlock";
 import { useFriend } from "./Profile/hooks/useFriend";
 import { useMike } from "./Profile/hooks/useMike";
+import { useMoreBoxOutsideClick } from "./Profile/hooks/useMoreBoxOutsideClick";
 import { usePosition } from "./Profile/hooks/usePosition";
 import { useProfileImage } from "./Profile/hooks/useProfileImage";
 import { useReport } from "./Profile/hooks/useReport";
 
 import type { RootState } from "@/redux/store";
 import type {
-  Mike as MikeType,
+  Mike,
   MoreBoxMenuItems,
   Position as PositionType,
   User,
@@ -68,7 +69,6 @@ const Profile: React.FC<Profile> = ({
   const { id } = useParams();
   const memberId = Number(id);
   const myId = useSelector((state: RootState) => state.user.id);
-  const moreBoxRef = useRef<HTMLDivElement | null>(null);
 
   /// hooks
   /* 마이크 상태 */
@@ -116,9 +116,12 @@ const Profile: React.FC<Profile> = ({
     setIsBlockConfirmOpen,
     handleRunBlock,
   } = useBlock(user, memberId, updateFriendState);
-  ///
 
   const [isMoreBoxOpen, setIsMoreBoxOpen] = useState(false);
+  const moreBoxRef = useMoreBoxOutsideClick(isMoreBoxOpen, () =>
+    setIsMoreBoxOpen(false)
+  );
+  ///
 
   /* 포지션 */
   const [isPositionOpen, setIsPositionOpen] = useState({
@@ -126,9 +129,6 @@ const Profile: React.FC<Profile> = ({
     sub: false,
     want: [false, false], // 최대 2개의 want 포지션
   });
-  const [selectedBox, setSelectedBox] = useState("");
-  const [showAlert, setShowAlert] = useState(false);
-  const matchInfo = useSelector((state: RootState) => state.matchInfo);
 
   // 상위 컴포넌트에서 user 변경 시 업데이트
   useEffect(() => {
@@ -179,8 +179,6 @@ const Profile: React.FC<Profile> = ({
   // 포지션 선택창 열기 (포지션 클릭시 동작)
   const handlePosition = (type: "main" | "sub" | "want", index: number = 0) => {
     if (profileType === "other") return;
-
-    setSelectedBox(type);
 
     setIsPositionOpen((prev) => {
       if (type === "want") {
@@ -308,28 +306,6 @@ const Profile: React.FC<Profile> = ({
     setIsMoreBoxOpen(false);
     setCheckedItems([]);
   };
-
-  // 더보기 외부 클릭
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        moreBoxRef.current &&
-        !moreBoxRef.current.contains(event.target as Node)
-      ) {
-        setIsMoreBoxOpen(false);
-      }
-    };
-
-    if (isMoreBoxOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    } else {
-      document.removeEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isMoreBoxOpen]);
 
   const handleMoreBoxOpen = () => {
     if (isDefault) {

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -13,18 +13,15 @@ import {
   Mic,
   MoreBox,
   MoreBoxButton,
-  PositionCategory,
   RankTier,
   Toggle,
   UpdateProfileImage,
 } from "@/components";
-import Icon from "@/components/common/Icon";
-import { POSITIONS, REPORT_REASON } from "@/constants";
+import { REPORT_REASON } from "@/constants";
 import { useMediaQueryContext } from "@/hooks";
 import { setMatchInfo } from "@/redux/slices/matchInfo";
 import { setOpenAlertModal } from "@/redux/slices/modalSlice";
 import { theme } from "@/styles/theme";
-import { setPositionImg } from "@/utils/custom";
 
 import GameStyle from "../match/GameStyle";
 import { useBlock } from "./Profile/hooks/useBlock";
@@ -34,14 +31,10 @@ import { useMoreBoxOutsideClick } from "./Profile/hooks/useMoreBoxOutsideClick";
 import { usePosition } from "./Profile/hooks/usePosition";
 import { useProfileImage } from "./Profile/hooks/useProfileImage";
 import { useReport } from "./Profile/hooks/useReport";
+import ProfilePositionSection from "./Profile/ProfilePositionSection";
 
 import type { RootState } from "@/redux/store";
-import type {
-  Mike,
-  MoreBoxMenuItems,
-  Position as PositionType,
-  User,
-} from "@/types";
+import type { MoreBoxMenuItems, Position as PositionType, User } from "@/types";
 
 type profileType = "normal" | "wind" | "other" | "me";
 
@@ -121,6 +114,7 @@ const Profile: React.FC<Profile> = ({
   const moreBoxRef = useMoreBoxOutsideClick(isMoreBoxOpen, () =>
     setIsMoreBoxOpen(false)
   );
+
   ///
 
   /* 포지션 */
@@ -383,139 +377,18 @@ const Profile: React.FC<Profile> = ({
           ) : (
             <UnderRow>
               {/* 칼바람 제외 클릭 시 */}
-              <Positions>
-                {/* 주 포지션 + 부 포지션 */}
-                <PosiWrap>
-                  {POSITIONS.slice(0, 2).map((position, index) => {
-                    const type = index === 0 ? "main" : "sub";
-
-                    return (
-                      <Posi
-                        key={index}
-                        className={profileType}
-                        $isWantP={false}
-                      >
-                        {position.label}
-                        <PosiItem>
-                          <Icon
-                            backgroundUrl={setPositionImg(
-                              type === "main"
-                                ? (positionValue.main ?? "ANY")
-                                : (positionValue.sub ?? "ANY")
-                            )}
-                            width={!isMobile ? 55 : 22}
-                            height={!isMobile ? 40 : 22}
-                            onClick={() => handlePosition(type)}
-                          />
-                          {isPositionOpen[type] && (
-                            <PositionCategory
-                              selectedBox={type}
-                              value={positionValue[type] ?? "ANY"}
-                              onClose={() => handlePositionClose(type)}
-                              onSelect={(val) =>
-                                handleCategoryButtonClick(val, type)
-                              }
-                            />
-                          )}
-                        </PosiItem>
-                      </Posi>
-                    );
-                  })}
-                </PosiWrap>
-
-                {/* 내가 찾는 포지션 */}
-                <PosiWrap>
-                  <Posi key={2} className={profileType} $isWantP={true}>
-                    {POSITIONS[2].label}
-                    <PosiRow>
-                      {positionValue?.want && positionValue?.want.length > 0 ? (
-                        positionValue.want
-                          .concat(Array(2).fill(null))
-                          .slice(0, 2)
-                          .map((posi, index) => (
-                            <PosiItem key={index}>
-                              {posi ? (
-                                <Icon
-                                  backgroundUrl={setPositionImg(posi)}
-                                  width={!isMobile ? 48 : 22}
-                                  height={!isMobile ? 40 : 22}
-                                  onClick={() => handlePosition("want", index)}
-                                />
-                              ) : (
-                                ["wind", "normal"].includes(profileType) && (
-                                  <Plus
-                                    onClick={() =>
-                                      handlePosition("want", index)
-                                    }
-                                  >
-                                    <Icon
-                                      backgroundUrl="/assets/icons/plus_violet.svg"
-                                      width={!isMobile ? 16 : 14}
-                                      height={!isMobile ? 16 : 14}
-                                    />
-                                  </Plus>
-                                )
-                              )}
-                              {/* PositionCategory 열기 조건 */}
-                              {isPositionOpen.want[index] && (
-                                <PositionCategory
-                                  selectedBox="want"
-                                  value={posi}
-                                  onClose={() =>
-                                    handlePositionClose("want", index)
-                                  }
-                                  onSelect={(val) =>
-                                    handleCategoryButtonClick(
-                                      val,
-                                      "want",
-                                      index
-                                    )
-                                  }
-                                  usedPositions={
-                                    positionValue.want?.filter(
-                                      (pos, i): pos is PositionType =>
-                                        i !== index && pos !== null
-                                    ) ?? []
-                                  }
-                                />
-                              )}
-                            </PosiItem>
-                          ))
-                      ) : // 매칭 프로필 - 포지션 선택, 조회 프로필 - ANY(*) 지정
-                      ["wind", "normal"].includes(profileType) ? (
-                        <PosiItem key="default-plus">
-                          <Plus onClick={() => handlePosition("want", 0)}>
-                            <Icon
-                              backgroundUrl="/assets/icons/plus_violet.svg"
-                              width={!isMobile ? 16 : 14}
-                              height={!isMobile ? 16 : 14}
-                            />
-                          </Plus>
-                          {isPositionOpen.want[0] && (
-                            <PositionCategory
-                              selectedBox="want"
-                              value={null}
-                              onClose={() => handlePositionClose("want", 0)}
-                              onSelect={(val) =>
-                                handleCategoryButtonClick(val, "want", 0)
-                              }
-                              usedPositions={[]}
-                            />
-                          )}
-                        </PosiItem>
-                      ) : (
-                        <PosiItem key="any-position">
-                          <Icon
-                            backgroundUrl={setPositionImg("ANY")}
-                            width={!isMobile ? 48 : 22}
-                            height={!isMobile ? 40 : 22}
-                          />
-                        </PosiItem>
-                      )}
-                    </PosiRow>
-                  </Posi>
-                </PosiWrap>
-              </Positions>
+              <ProfilePositionSection
+                profileType={profileType}
+                isMobile={isMobile}
+                isPositionOpen={isPositionOpen}
+                positionValue={{
+                  ...positionValue,
+                  want: positionValue.want ?? [],
+                }}
+                handlePosition={handlePosition}
+                handlePositionClose={handlePositionClose}
+                handleCategoryButtonClick={handleCategoryButtonClick}
+              />
               {!isMobile &&
                 (profileType === "other" || profileType === "me") &&
                 user.championResponseList && (
@@ -874,83 +747,6 @@ const MsgConfirm = styled(Msg)`
   @media (max-width: ${theme.breakpoints.mobile}) {
     ${(props) => props.theme.fonts.medium14};
     margin: 32px 0;
-  }
-`;
-
-const Positions = styled.div`
-  display: flex;
-  align-items: center;
-  width: 412px;
-  gap: 12px;
-  @media (max-width: ${theme.breakpoints.mobile}) {
-    width: 100%;
-  }
-`;
-
-const PosiWrap = styled.div`
-  height: 104px;
-  display: flex;
-  justify-content: center;
-  gap: 12px;
-  background-color: ${theme.colors.white};
-  width: 100%;
-  border-radius: 6px;
-  padding: 16px 32px 12px 32px;
-
-  @media (max-width: ${theme.breakpoints.mobile}) {
-    height: 69px;
-    padding: 12px 20px 8px 20px;
-  }
-`;
-
-const Posi = styled.div<{ $isWantP: boolean }>`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  align-items: center;
-  font-size: ${theme.fonts.medium16};
-  color: ${theme.colors.gray800};
-  white-space: nowrap;
-
-  @media (max-width: ${theme.breakpoints.mobile}) {
-    font-size: ${theme.fonts.medium11};
-    gap: 9px;
-    ${({ $isWantP }) =>
-      $isWantP &&
-      css`
-        margin-left: 0px;
-      `};
-  }
-`;
-
-const PosiRow = styled.div`
-  height: 40px;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  gap: 12px;
-`;
-
-const PosiItem = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-`;
-
-const Plus = styled.div`
-  display: flex;
-  width: 48px;
-  height: 32px;
-  justify-content: center;
-  align-items: center;
-  border-radius: 999px;
-  background: ${theme.colors.violet100};
-
-  @media (max-width: ${theme.breakpoints.mobile}) {
-    width: 32px;
-    height: 24px;
   }
 `;
 

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -4,15 +4,6 @@ import { useParams } from "next/navigation";
 import styled, { css } from "styled-components";
 
 import {
-  acceptFriendRequest,
-  blockMember,
-  cancelFriendRequest,
-  deleteFriend,
-  rejectFriendRequest,
-  sendFriendRequest,
-  unblockMember,
-} from "@/api";
-import {
   Button,
   Champion,
   Checkbox,
@@ -36,6 +27,8 @@ import { theme } from "@/styles/theme";
 import { setPositionImg } from "@/utils/custom";
 
 import GameStyle from "../match/GameStyle";
+import { useBlock } from "./Profile/hooks/useBlock";
+import { useFriend } from "./Profile/hooks/useFriend";
 import { useMike } from "./Profile/hooks/useMike";
 import { usePosition } from "./Profile/hooks/usePosition";
 import { useProfileImage } from "./Profile/hooks/useProfileImage";
@@ -108,11 +101,24 @@ const Profile: React.FC<Profile> = ({
     handleRunReport,
   } = useReport(memberId, myId || 0);
 
+  const { handleFriendState } = useFriend(
+    user,
+    myId || 0,
+    memberId,
+    updateFriendState
+  );
+
+  /* 차단 상태 */
+  const {
+    isBlockBoxOpen,
+    setIsBlockBoxOpen,
+    isBlockConfirmOpen,
+    setIsBlockConfirmOpen,
+    handleRunBlock,
+  } = useBlock(user, memberId, updateFriendState);
   ///
 
   const [isMoreBoxOpen, setIsMoreBoxOpen] = useState(false);
-  const [isBlockBoxOpen, setIsBlockBoxOpen] = useState(false);
-  const [isBlockConfirmOpen, setIsBlockConfrimOpen] = useState(false);
 
   /* 포지션 */
   const [isPositionOpen, setIsPositionOpen] = useState({
@@ -167,27 +173,6 @@ const Profile: React.FC<Profile> = ({
   const handleBlock = async () => {
     setIsBlockBoxOpen(!isBlockBoxOpen);
     setIsMoreBoxOpen(false);
-  };
-
-  const handleRunBlock = async () => {
-    // 차단하기 api
-    setIsBlockBoxOpen(false);
-    if (user.blocked) {
-      await unblockMember(memberId);
-      updateFriendState?.({
-        friend: user.friend,
-        friendRequestMemberId: user.friendRequestMemberId,
-        blocked: false,
-      });
-    } else {
-      await blockMember(memberId);
-      updateFriendState?.({
-        friend: user.friend,
-        friendRequestMemberId: user.friendRequestMemberId,
-        blocked: true,
-      });
-    }
-    setIsBlockConfrimOpen(true);
   };
 
   /* 포지션 선택창 관련 함수*/
@@ -255,57 +240,6 @@ const Profile: React.FC<Profile> = ({
 
     setPositionValue(newPositionValue);
     handlePositionChange(newPositionValue);
-  };
-
-  const handleFriendState = async (state: string) => {
-    try {
-      switch (state) {
-        case "add":
-          await sendFriendRequest(memberId);
-          updateFriendState?.({
-            friend: false,
-            friendRequestMemberId: myId || null,
-            blocked: user.blocked,
-          });
-          break;
-        case "cancel":
-          await cancelFriendRequest(memberId);
-          updateFriendState?.({
-            friend: false,
-            friendRequestMemberId: null,
-            blocked: user.blocked,
-          });
-          break;
-        case "accept":
-          await acceptFriendRequest(memberId);
-          updateFriendState?.({
-            friend: true,
-            friendRequestMemberId: memberId,
-            blocked: user.blocked,
-          });
-          break;
-        case "reject":
-          await rejectFriendRequest(memberId);
-          updateFriendState?.({
-            friend: false,
-            friendRequestMemberId: null,
-            blocked: user.blocked,
-          });
-          break;
-        case "delete":
-          await deleteFriend(memberId);
-          updateFriendState?.({
-            friend: false,
-            friendRequestMemberId: null,
-            blocked: user.blocked,
-          });
-          break;
-        default:
-          throw new Error("존재하지 않는 친구 상태입니다.");
-      }
-    } catch (error) {
-      console.error("Error handling friend state:", error);
-    }
   };
 
   const renderFriendsButton = () => {
@@ -745,7 +679,7 @@ const Profile: React.FC<Profile> = ({
               width="540px"
               primaryButtonText="확인"
               onPrimaryClick={() => {
-                setIsBlockConfrimOpen(false);
+                setIsBlockConfirmOpen(false);
               }}
             >
               <MsgConfirm>{`${

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -9,7 +9,6 @@ import {
   cancelFriendRequest,
   deleteFriend,
   putPosition,
-  putProfileImage,
   rejectFriendRequest,
   reportMember,
   sendFriendRequest,
@@ -33,13 +32,14 @@ import {
 import Icon from "@/components/common/Icon";
 import { POSITIONS, REPORT_REASON } from "@/constants";
 import { useMediaQueryContext } from "@/hooks";
-import { setMatchInfo, updateMike } from "@/redux/slices/matchInfo";
+import { setMatchInfo } from "@/redux/slices/matchInfo";
 import { setOpenAlertModal } from "@/redux/slices/modalSlice";
-import { setUserProfileImg } from "@/redux/slices/userSlice";
 import { theme } from "@/styles/theme";
 import { setPositionImg } from "@/utils/custom";
 
 import GameStyle from "../match/GameStyle";
+import { useMike } from "./Profile/hooks/useMike";
+import { useProfileImage } from "./Profile/hooks/useProfileImage";
 
 import type { RootState } from "@/redux/store";
 import type {
@@ -78,11 +78,24 @@ const Profile: React.FC<Profile> = ({
   const myId = useSelector((state: RootState) => state.user.id);
   const moreBoxRef = useRef<HTMLDivElement | null>(null);
 
+  // hooks
+  /* 마이크 상태 */
+  const { isMike, handleMike, setIsMike } = useMike(user);
+
+  /* 프로필 이미지 */
+  const {
+    selectedImageIndex,
+    setSelectedImageIndex,
+    isProfileListOpen,
+    setIsProfileListOpen,
+    handleImageClick,
+  } = useProfileImage(user);
+
   const [isMoreBoxOpen, setIsMoreBoxOpen] = useState(false);
   const [isReportBoxOpen, setIsReportBoxOpen] = useState(false);
   const [isBlockBoxOpen, setIsBlockBoxOpen] = useState(false);
   const [isBlockConfirmOpen, setIsBlockConfrimOpen] = useState(false);
-  const [isProfileListOpen, setIsProfileListOpen] = useState(false);
+
   /* 신고 input */
   const [checkedItems, setCheckedItems] = useState<number[]>([]);
   const [reportDetail, setReportDetail] = useState<string>("");
@@ -98,16 +111,11 @@ const Profile: React.FC<Profile> = ({
   const matchInfo = useSelector((state: RootState) => state.matchInfo);
 
   /* user부터 가져오는 상태들 */
-  const [isMike, setIsMike] = useState<MikeType>(user.mike);
   const [positionValue, setPositionValue] = useState<PositionState>({
     main: user.mainP,
     sub: user.subP,
     want: user.wantP,
   });
-  /* 선택된 현재 프로필 이미지 */
-  const [selectedImageIndex, setSelectedImageIndex] = useState<number>(
-    user.profileImg
-  );
 
   // 상위 컴포넌트에서 user 변경 시 업데이트
   useEffect(() => {
@@ -140,28 +148,9 @@ const Profile: React.FC<Profile> = ({
     [isMike, positionValue, dispatch]
   );
 
-  /* 프로필 이미지 리스트 중 클릭시*/
-  const handleImageClick = async (index: number) => {
-    setSelectedImageIndex(index);
-
-    await putProfileImage(index);
-    // const newUserData = await getProfile();
-    dispatch(setUserProfileImg(index));
-    localStorage.setItem("profileImg", index + "");
-
-    setTimeout(() => {
-      setIsProfileListOpen(false);
-    }, 300); // 300ms 후에 창이 닫히도록 설정
-  };
-
   useEffect(() => {
     setIsMike(isMike);
   }, [isMike]);
-
-  const handleMike = () => {
-    setIsMike(isMike === "AVAILABLE" ? "UNAVAILABLE" : "AVAILABLE");
-    dispatch(updateMike(isMike));
-  };
 
   const handleReport = () => {
     setIsReportBoxOpen(!isReportBoxOpen);

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -364,75 +364,58 @@ const Profile: React.FC<Profile> = ({
     }
   };
 
-  // 친구 추가
   const renderFriendsButton = () => {
-    // 친구 추가
-    // 친구 삭제 (끊기)
-    // 친구 요청 전송 (나)
-    // 친구 요청 취소 (나)
-    // 친구 수락/거절 (상대)
-    // 자기 자신 프로필
-    if (user.blocked) {
+    if (isDefault || user.blocked) return null;
+    if (memberId === myId || user.id === myId) return null;
+
+    const width = isMobile ? "100%" : "218px";
+
+    // 친구 요청 수락/거절 버튼만 예외적으로 두 개라서 따로 처리
+    if (user.friendRequestMemberId === memberId) {
       return (
-        // <Button
-        //   buttonType="secondary"
-        //   width="218px"
-        //   text="차단된 유저"
-        //   disabled={true}
-        // />
-        null
-      );
-    }
-    if (user.friend) {
-      return (
-        <Button
-          buttonType="secondary"
-          width={isMobile ? "100%" : "218px"}
-          text="친구 삭제"
-          onClick={() => handleFriendState("delete")}
-        />
-      );
-    } else {
-      if (user.friendRequestMemberId) {
-        if (user.friendRequestMemberId === memberId) {
-          return (
-            <FriendRow>
-              <Button
-                buttonType="secondary"
-                width={isMobile ? "100%" : "163px"}
-                text="친구 거절"
-                onClick={() => handleFriendState("reject")}
-              />
-              <Button
-                buttonType="primary"
-                width={isMobile ? "100%" : "163px"}
-                text="친구 수락"
-                onClick={() => handleFriendState("accept")}
-              />
-            </FriendRow>
-          );
-        } else {
-          return (
+        <Admit>
+          <FriendRow>
             <Button
               buttonType="secondary"
-              width={isMobile ? "100%" : "218px"}
-              text="친구 요청 취소"
-              onClick={() => handleFriendState("cancel")}
+              width={width}
+              text="친구 거절"
+              onClick={() => handleFriendState("reject")}
             />
-          );
-        }
-      } else if (memberId === myId || user.id === myId) {
-        return null;
-      }
-      return (
-        <Button
-          buttonType="secondary"
-          width={isMobile ? "100%" : "218px"}
-          text="친구 추가"
-          onClick={() => handleFriendState("add")}
-        />
+            <Button
+              buttonType="primary"
+              width="163px"
+              text="친구 수락"
+              onClick={() => handleFriendState("accept")}
+            />
+          </FriendRow>
+        </Admit>
       );
     }
+
+    let text = "";
+    let onClick: () => void;
+
+    if (user.friend) {
+      text = "친구 삭제";
+      onClick = () => handleFriendState("delete");
+    } else if (user.friendRequestMemberId) {
+      text = "친구 요청 취소";
+      onClick = () => handleFriendState("cancel");
+    } else {
+      text = "친구 추가";
+      onClick = () => handleFriendState("add");
+    }
+
+    return (
+      <Admit>
+        <Button
+          buttonType="secondary"
+          width={width}
+          text={text}
+          onClick={onClick}
+        />
+      </Admit>
+    );
   };
 
   // 더보기 버튼 메뉴
@@ -539,7 +522,6 @@ const Profile: React.FC<Profile> = ({
               </Top>
             </TopContainer>
           )}
-
           <RankTierWrapper>
             <RankTier type="solo" tier={user.soloTier} rank={user.soloRank} />
             <RankTier type="free" tier={user.freeTier} rank={user.freeRank} />
@@ -711,9 +693,7 @@ const Profile: React.FC<Profile> = ({
               handleMike={handleMike}
             />
           )}
-          {!isDefault && isTablet && !isMobile && (
-            <Admit>{renderFriendsButton()}</Admit>
-          )}
+          {isTablet && !isMobile && renderFriendsButton()}
           {(profileType === "normal" || profileType === "wind") && (
             <Mike>
               마이크
@@ -730,16 +710,15 @@ const Profile: React.FC<Profile> = ({
               />
             )}
         </StyledBox>
-        {!isDefault &&
-          isMobile &&
-          (profileType === "me" || profileType === "other") && (
-            <Admit>{renderFriendsButton()}</Admit>
-          )}
+        {/* {isMobile &&
+          (profileType === "me" || profileType === "other") &&
+          renderFriendsButton()} */}
+        {isMobile && renderFriendsButton()}
       </Row>
 
       {profileType === "other" && (
         <More>
-          {!isDefault && !isTablet && <Admit>{renderFriendsButton()}</Admit>}
+          {!isTablet && renderFriendsButton()}
           {/* 더보기 버튼 */}
           {memberId !== myId && (
             <MoreDiv ref={moreBoxRef}>

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -8,7 +8,6 @@ import {
   blockMember,
   cancelFriendRequest,
   deleteFriend,
-  putPosition,
   rejectFriendRequest,
   reportMember,
   sendFriendRequest,
@@ -39,6 +38,7 @@ import { setPositionImg } from "@/utils/custom";
 
 import GameStyle from "../match/GameStyle";
 import { useMike } from "./Profile/hooks/useMike";
+import { usePosition } from "./Profile/hooks/usePosition";
 import { useProfileImage } from "./Profile/hooks/useProfileImage";
 
 import type { RootState } from "@/redux/store";
@@ -48,7 +48,6 @@ import type {
   Position as PositionType,
   User,
 } from "@/types";
-import type { PositionState } from "../crBoard/PositionBox";
 
 type profileType = "normal" | "wind" | "other" | "me";
 
@@ -91,6 +90,12 @@ const Profile: React.FC<Profile> = ({
     handleImageClick,
   } = useProfileImage(user);
 
+  /* 포지션 */
+  const { positionValue, setPositionValue, handlePositionChange } = usePosition(
+    user,
+    profileType
+  );
+
   const [isMoreBoxOpen, setIsMoreBoxOpen] = useState(false);
   const [isReportBoxOpen, setIsReportBoxOpen] = useState(false);
   const [isBlockBoxOpen, setIsBlockBoxOpen] = useState(false);
@@ -109,13 +114,6 @@ const Profile: React.FC<Profile> = ({
   const [selectedBox, setSelectedBox] = useState("");
   const [showAlert, setShowAlert] = useState(false);
   const matchInfo = useSelector((state: RootState) => state.matchInfo);
-
-  /* user부터 가져오는 상태들 */
-  const [positionValue, setPositionValue] = useState<PositionState>({
-    main: user.mainP,
-    sub: user.subP,
-    want: user.wantP,
-  });
 
   // 상위 컴포넌트에서 user 변경 시 업데이트
   useEffect(() => {
@@ -248,38 +246,6 @@ const Profile: React.FC<Profile> = ({
         return { ...prev, [type]: false };
       }
     });
-  };
-
-  // 포지션 선택해 변경하기
-  const handlePositionChange = async (newPositionValue: PositionState) => {
-    if (
-      profileType !== "other" &&
-      newPositionValue.main &&
-      newPositionValue.sub
-    ) {
-      try {
-        // 포지션 변경 API 호출
-        await putPosition({
-          mainP: newPositionValue.main,
-          subP: newPositionValue.sub,
-          wantP: newPositionValue.want || [],
-        });
-
-        // 포지션 상태 업데이트
-        setPositionValue(newPositionValue);
-      } catch (error) {
-        console.error("포지션 변경 실패:", error);
-      }
-    } else if (profileType === "normal" || profileType === "wind") {
-      dispatch(
-        setMatchInfo({
-          ...matchInfo,
-          mainP: newPositionValue.main ?? "ANY",
-          subP: newPositionValue.sub ?? "ANY",
-          wantP: newPositionValue.want ?? ["ANY", "ANY"],
-        })
-      );
-    }
   };
 
   const handleCategoryButtonClick = (

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -9,7 +9,6 @@ import {
   cancelFriendRequest,
   deleteFriend,
   rejectFriendRequest,
-  reportMember,
   sendFriendRequest,
   unblockMember,
 } from "@/api";
@@ -40,6 +39,7 @@ import GameStyle from "../match/GameStyle";
 import { useMike } from "./Profile/hooks/useMike";
 import { usePosition } from "./Profile/hooks/usePosition";
 import { useProfileImage } from "./Profile/hooks/useProfileImage";
+import { useReport } from "./Profile/hooks/useReport";
 
 import type { RootState } from "@/redux/store";
 import type {
@@ -77,7 +77,7 @@ const Profile: React.FC<Profile> = ({
   const myId = useSelector((state: RootState) => state.user.id);
   const moreBoxRef = useRef<HTMLDivElement | null>(null);
 
-  // hooks
+  /// hooks
   /* 마이크 상태 */
   const { isMike, handleMike, setIsMike } = useMike(user);
 
@@ -96,14 +96,23 @@ const Profile: React.FC<Profile> = ({
     profileType
   );
 
+  /* 신고 상태 */
+  const {
+    isReportBoxOpen,
+    setIsReportBoxOpen,
+    handleCheckboxChange,
+    checkedItems,
+    setCheckedItems,
+    reportDetail,
+    setReportDetail,
+    handleRunReport,
+  } = useReport(memberId, myId || 0);
+
+  ///
+
   const [isMoreBoxOpen, setIsMoreBoxOpen] = useState(false);
-  const [isReportBoxOpen, setIsReportBoxOpen] = useState(false);
   const [isBlockBoxOpen, setIsBlockBoxOpen] = useState(false);
   const [isBlockConfirmOpen, setIsBlockConfrimOpen] = useState(false);
-
-  /* 신고 input */
-  const [checkedItems, setCheckedItems] = useState<number[]>([]);
-  const [reportDetail, setReportDetail] = useState<string>("");
 
   /* 포지션 */
   const [isPositionOpen, setIsPositionOpen] = useState({
@@ -153,26 +162,6 @@ const Profile: React.FC<Profile> = ({
   const handleReport = () => {
     setIsReportBoxOpen(!isReportBoxOpen);
     setIsMoreBoxOpen(false);
-  };
-
-  const handleRunReport = async () => {
-    // 신고하기 api
-    if (myId === memberId) return;
-
-    const params = {
-      memberId: memberId,
-      reportCodeList: checkedItems,
-      contents: reportDetail,
-      pathCode: 3, // PROFILE
-    };
-
-    setIsMoreBoxOpen(false);
-    try {
-      await reportMember(params);
-      setIsReportBoxOpen(!isReportBoxOpen);
-    } catch (error) {
-      console.error("에러:", error);
-    }
   };
 
   const handleBlock = async () => {
@@ -378,15 +367,6 @@ const Profile: React.FC<Profile> = ({
     { text: "신고하기", onClick: handleReport },
     { text: user.blocked ? "차단 해제" : "차단하기", onClick: handleBlock },
   ];
-
-  // 신고하기 체크
-  const handleCheckboxChange = (checked: number) => {
-    setCheckedItems((prev) =>
-      prev.includes(checked)
-        ? prev.filter((c) => c !== checked)
-        : [...prev, checked]
-    );
-  };
 
   // 신고하기 모달 닫기
   const handleReportBoxClose = () => {

--- a/src/components/profile/Profile/ProfilePositionSection.tsx
+++ b/src/components/profile/Profile/ProfilePositionSection.tsx
@@ -1,0 +1,239 @@
+import React from "react";
+import styled, { css } from "styled-components";
+
+import { PositionCategory } from "@/components";
+import Icon from "@/components/common/Icon";
+import { POSITIONS } from "@/constants";
+import { theme } from "@/styles/theme";
+import { setPositionImg } from "@/utils/custom";
+
+import type { Position, PositionType } from "@/types";
+
+interface Props {
+  profileType: "normal" | "wind" | "other" | "me";
+  isMobile: boolean;
+  isPositionOpen: {
+    main: boolean;
+    sub: boolean;
+    want: boolean[];
+  };
+  positionValue: {
+    main: Position | null;
+    sub: Position | null;
+    want: (Position | null)[];
+  };
+  handlePosition: (type: PositionType, index?: number) => void;
+  handlePositionClose: (type: PositionType, index?: number) => void;
+  handleCategoryButtonClick: (
+    selectedValue: Position | null,
+    type: PositionType,
+    index?: number
+  ) => void;
+}
+
+const ProfilePositionSection: React.FC<Props> = ({
+  profileType,
+  isMobile,
+  isPositionOpen,
+  positionValue,
+  handlePosition,
+  handlePositionClose,
+  handleCategoryButtonClick,
+}) => {
+  return (
+    <Positions>
+      {/* 주/부 포지션 */}
+      <PosiWrap>
+        {POSITIONS.slice(0, 2).map((position, index) => {
+          const type = index === 0 ? "main" : "sub";
+          return (
+            <Posi key={index} className={profileType} $isWantP={false}>
+              {position.label}
+              <PosiItem>
+                <Icon
+                  backgroundUrl={setPositionImg(
+                    type === "main"
+                      ? (positionValue.main ?? "ANY")
+                      : (positionValue.sub ?? "ANY")
+                  )}
+                  width={!isMobile ? 55 : 22}
+                  height={!isMobile ? 40 : 22}
+                  onClick={() => handlePosition(type)}
+                />
+                {isPositionOpen[type] && (
+                  <PositionCategory
+                    selectedBox={type}
+                    value={positionValue[type] ?? "ANY"}
+                    onClose={() => handlePositionClose(type)}
+                    onSelect={(val) => handleCategoryButtonClick(val, type)}
+                  />
+                )}
+              </PosiItem>
+            </Posi>
+          );
+        })}
+      </PosiWrap>
+
+      {/* 내가 원하는 포지션 */}
+      <PosiWrap>
+        <Posi className={profileType} $isWantP={true}>
+          {POSITIONS[2].label}
+          <PosiRow>
+            {positionValue.want?.length > 0 ? (
+              positionValue.want
+                .concat(Array(2).fill(null))
+                .slice(0, 2)
+                .map((posi, index) => (
+                  <PosiItem key={index}>
+                    {posi ? (
+                      <Icon
+                        backgroundUrl={setPositionImg(posi)}
+                        width={!isMobile ? 48 : 22}
+                        height={!isMobile ? 40 : 22}
+                        onClick={() => handlePosition("want", index)}
+                      />
+                    ) : (
+                      ["wind", "normal"].includes(profileType) && (
+                        <Plus onClick={() => handlePosition("want", index)}>
+                          <Icon
+                            backgroundUrl="/assets/icons/plus_violet.svg"
+                            width={!isMobile ? 16 : 14}
+                            height={!isMobile ? 16 : 14}
+                          />
+                        </Plus>
+                      )
+                    )}
+                    {/* PositionCategory 열기 조건 */}
+                    {isPositionOpen.want[index] && (
+                      <PositionCategory
+                        selectedBox="want"
+                        value={posi}
+                        onClose={() => handlePositionClose("want", index)}
+                        onSelect={(val) =>
+                          handleCategoryButtonClick(val, "want", index)
+                        }
+                        usedPositions={
+                          positionValue.want?.filter(
+                            (p, i): p is Position => i !== index && p !== null
+                          ) ?? []
+                        }
+                      />
+                    )}
+                  </PosiItem>
+                ))
+            ) : // 매칭 프로필 - 포지션 선택, 조회 프로필 - ANY(*) 지정
+            ["wind", "normal"].includes(profileType) ? (
+              <PosiItem>
+                <Plus onClick={() => handlePosition("want", 0)}>
+                  <Icon
+                    backgroundUrl="/assets/icons/plus_violet.svg"
+                    width={!isMobile ? 16 : 14}
+                    height={!isMobile ? 16 : 14}
+                  />
+                </Plus>
+                {isPositionOpen.want[0] && (
+                  <PositionCategory
+                    selectedBox="want"
+                    value={null}
+                    onClose={() => handlePositionClose("want", 0)}
+                    onSelect={(val) =>
+                      handleCategoryButtonClick(val, "want", 0)
+                    }
+                    usedPositions={[]}
+                  />
+                )}
+              </PosiItem>
+            ) : (
+              <PosiItem>
+                <Icon
+                  backgroundUrl={setPositionImg("ANY")}
+                  width={!isMobile ? 48 : 22}
+                  height={!isMobile ? 40 : 22}
+                />
+              </PosiItem>
+            )}
+          </PosiRow>
+        </Posi>
+      </PosiWrap>
+    </Positions>
+  );
+};
+
+export default ProfilePositionSection;
+
+const Positions = styled.div`
+  display: flex;
+  align-items: center;
+  width: 412px;
+  gap: 12px;
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    width: 100%;
+  }
+`;
+
+const PosiWrap = styled.div`
+  height: 104px;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  background-color: ${theme.colors.white};
+  width: 100%;
+  border-radius: 6px;
+  padding: 16px 32px 12px 32px;
+
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    height: 69px;
+    padding: 12px 20px 8px 20px;
+  }
+`;
+
+const Posi = styled.div<{ $isWantP: boolean }>`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  font-size: ${theme.fonts.medium16};
+  color: ${theme.colors.gray800};
+  white-space: nowrap;
+
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    font-size: ${theme.fonts.medium11};
+    gap: 9px;
+    ${({ $isWantP }) =>
+      $isWantP &&
+      css`
+        margin-left: 0px;
+      `};
+  }
+`;
+
+const PosiRow = styled.div`
+  height: 40px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+`;
+
+const PosiItem = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+`;
+
+const Plus = styled.div`
+  display: flex;
+  width: 48px;
+  height: 32px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 999px;
+  background: ${theme.colors.violet100};
+
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    width: 32px;
+    height: 24px;
+  }
+`;

--- a/src/components/profile/Profile/hooks/useBlock.tsx
+++ b/src/components/profile/Profile/hooks/useBlock.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+
+import { blockMember, unblockMember } from "@/api";
+
+import type { User } from "@/types";
+
+export const useBlock = (
+  user: User,
+  memberId: number,
+  updateFriendState?: (state: {
+    friend: boolean;
+    friendRequestMemberId: number | null;
+    blocked: boolean;
+  }) => void
+) => {
+  const [isBlockBoxOpen, setIsBlockBoxOpen] = useState(false);
+  const [isBlockConfirmOpen, setIsBlockConfirmOpen] = useState(false);
+
+  const handleRunBlock = async () => {
+    setIsBlockBoxOpen(false);
+
+    try {
+      if (user.blocked) {
+        // 차단해제 api
+        await unblockMember(memberId);
+        updateFriendState?.({
+          friend: user.friend,
+          friendRequestMemberId: user.friendRequestMemberId,
+          blocked: false,
+        });
+      } else {
+        // 차단하기 api
+        await blockMember(memberId);
+        updateFriendState?.({
+          friend: user.friend,
+          friendRequestMemberId: user.friendRequestMemberId,
+          blocked: true,
+        });
+      }
+      setIsBlockConfirmOpen(true);
+    } catch (error) {
+      console.error("Block/unblock failed", error);
+    }
+  };
+
+  return {
+    isBlockBoxOpen,
+    setIsBlockBoxOpen,
+    isBlockConfirmOpen,
+    setIsBlockConfirmOpen,
+    handleRunBlock,
+  };
+};

--- a/src/components/profile/Profile/hooks/useFriend.tsx
+++ b/src/components/profile/Profile/hooks/useFriend.tsx
@@ -1,0 +1,68 @@
+import {
+  acceptFriendRequest,
+  cancelFriendRequest,
+  deleteFriend,
+  rejectFriendRequest,
+  sendFriendRequest,
+} from "@/api";
+
+import type { User } from "@/types";
+
+export const useFriend = (
+  user: User,
+  myId: number,
+  memberId: number,
+  updateFriendState?: (state: {
+    friend: boolean;
+    friendRequestMemberId: number | null;
+    blocked: boolean;
+  }) => void
+) => {
+  const handleFriendState = async (action: string) => {
+    const update = (
+      data: Partial<{
+        friend: boolean;
+        friendRequestMemberId: number | null;
+        blocked: boolean;
+      }>
+    ) => {
+      updateFriendState?.({
+        friend: data.friend ?? user.friend,
+        friendRequestMemberId:
+          data.friendRequestMemberId ?? user.friendRequestMemberId,
+        blocked: data.blocked ?? user.blocked,
+      });
+    };
+
+    try {
+      switch (action) {
+        case "add":
+          await sendFriendRequest(memberId);
+          update({ friendRequestMemberId: myId });
+          break;
+        case "cancel":
+          await cancelFriendRequest(memberId);
+          update({ friendRequestMemberId: null });
+          break;
+        case "accept":
+          await acceptFriendRequest(memberId);
+          update({ friend: true, friendRequestMemberId: memberId });
+          break;
+        case "reject":
+          await rejectFriendRequest(memberId);
+          update({ friendRequestMemberId: null });
+          break;
+        case "delete":
+          await deleteFriend(memberId);
+          update({ friend: false, friendRequestMemberId: null });
+          break;
+        default:
+          throw new Error("존재하지 않는 친구 상태입니다.");
+      }
+    } catch (err) {
+      console.error("Friend action failed", err);
+    }
+  };
+
+  return { handleFriendState };
+};

--- a/src/components/profile/Profile/hooks/useMike.tsx
+++ b/src/components/profile/Profile/hooks/useMike.tsx
@@ -1,0 +1,19 @@
+import { useState } from "react";
+import { useDispatch } from "react-redux";
+
+import { updateMike } from "@/redux/slices/matchInfo";
+
+import type { Mike as MikeType, User } from "@/types";
+
+export const useMike = (user: User) => {
+  const dispatch = useDispatch();
+  const [isMike, setIsMike] = useState<MikeType>(user.mike);
+
+  const handleMike = () => {
+    const next = isMike === "AVAILABLE" ? "UNAVAILABLE" : "AVAILABLE";
+    setIsMike(next);
+    dispatch(updateMike(next));
+  };
+
+  return { isMike, handleMike, setIsMike };
+};

--- a/src/components/profile/Profile/hooks/useMoreBoxOutsideClick.tsx
+++ b/src/components/profile/Profile/hooks/useMoreBoxOutsideClick.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from "react";
+
+export const useMoreBoxOutsideClick = (
+  isOpen: boolean,
+  onClose: () => void
+) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    if (isOpen) document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, onClose]);
+
+  return ref;
+};

--- a/src/components/profile/Profile/hooks/usePosition.tsx
+++ b/src/components/profile/Profile/hooks/usePosition.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { putPosition } from "@/api";
+import { setMatchInfo } from "@/redux/slices/matchInfo";
+
+import type { PositionState } from "@/components/crBoard/PositionBox";
+import type { RootState } from "@/redux/store";
+import type { User } from "@/types";
+
+export const usePosition = (user: User, profileType: string) => {
+  const dispatch = useDispatch();
+  const matchInfo = useSelector((state: RootState) => state.matchInfo);
+
+  const [positionValue, setPositionValue] = useState<PositionState>({
+    main: user.mainP,
+    sub: user.subP,
+    want: user.wantP,
+  });
+
+  // 포지션 선택해 변경하기
+  const handlePositionChange = async (newPosition: PositionState) => {
+    if (profileType !== "other" && newPosition.main && newPosition.sub) {
+      try {
+        // 포지션 변경 API 호출
+        await putPosition({
+          mainP: newPosition.main,
+          subP: newPosition.sub,
+          wantP: newPosition.want || [],
+        });
+        // 포지션 상태 업데이트
+        setPositionValue(newPosition);
+      } catch (err) {
+        console.error("Position update failed", err);
+      }
+    } else if (["normal", "wind"].includes(profileType)) {
+      dispatch(
+        setMatchInfo({
+          ...matchInfo,
+          mainP: newPosition.main ?? "ANY",
+          subP: newPosition.sub ?? "ANY",
+          wantP: newPosition.want ?? ["ANY", "ANY"],
+        })
+      );
+    }
+  };
+
+  return { positionValue, setPositionValue, handlePositionChange };
+};

--- a/src/components/profile/Profile/hooks/useProfileImage.tsx
+++ b/src/components/profile/Profile/hooks/useProfileImage.tsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { useDispatch } from "react-redux";
+
+import { putProfileImage } from "@/api";
+import { STORAGE_KEY } from "@/constants/storage";
+import { setUserProfileImg } from "@/redux/slices/userSlice";
+
+import type { User } from "@/types";
+
+export const useProfileImage = (user: User) => {
+  const dispatch = useDispatch();
+  const [selectedImageIndex, setSelectedImageIndex] = useState<number>(
+    user.profileImg
+  );
+  const [isProfileListOpen, setIsProfileListOpen] = useState(false);
+
+  const handleImageClick = async (index: number) => {
+    setSelectedImageIndex(index);
+    await putProfileImage(index);
+    dispatch(setUserProfileImg(index));
+    localStorage.setItem(STORAGE_KEY.profileImg, String(index));
+    setTimeout(() => setIsProfileListOpen(false), 300);
+  };
+
+  return {
+    selectedImageIndex,
+    setSelectedImageIndex,
+    isProfileListOpen,
+    setIsProfileListOpen,
+    handleImageClick,
+  };
+};

--- a/src/components/profile/Profile/hooks/useReport.tsx
+++ b/src/components/profile/Profile/hooks/useReport.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+
+import { reportMember } from "@/api";
+
+export const useReport = (memberId: number, myId: number) => {
+  const [isReportBoxOpen, setIsReportBoxOpen] = useState(false);
+  const [checkedItems, setCheckedItems] = useState<number[]>([]);
+  const [reportDetail, setReportDetail] = useState<string>("");
+
+  // 신고하기 체크
+  const handleCheckboxChange = (id: number) => {
+    setCheckedItems((prev) =>
+      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
+    );
+  };
+
+  const handleRunReport = async () => {
+    if (myId === memberId) return;
+    const params = {
+      memberId,
+      reportCodeList: checkedItems,
+      contents: reportDetail,
+      pathCode: 3,
+    };
+
+    try {
+      await reportMember(params);
+      setIsReportBoxOpen(false);
+    } catch (error) {
+      console.error("Report failed", error);
+    }
+  };
+
+  return {
+    isReportBoxOpen,
+    setIsReportBoxOpen,
+    handleCheckboxChange,
+    checkedItems,
+    setCheckedItems,
+    reportDetail,
+    setReportDetail,
+    handleRunReport,
+  };
+};

--- a/src/types/api/board/board.d.ts
+++ b/src/types/api/board/board.d.ts
@@ -127,7 +127,7 @@ export interface MemberPostBoardData
   isFriend: boolean;
   friendRequestMemberId: number;
   createdAt: string;
-  bumpTime: string; // TODO: 서버 응답 추가 필요
+  bumpTime: string;
   mannerLevel: number;
   mannerKeywords: MannerKeywordDTO[];
 }
@@ -142,7 +142,7 @@ export interface NotMemberBoardData
   soloRank: number;
   freeRank: number;
   createdAt: string;
-  bumpTime: string; // TODO: 서버 응답 추가 필요
+  bumpTime: string;
   mannerLevel: number;
 }
 

--- a/src/utils/custom.tsx
+++ b/src/utils/custom.tsx
@@ -59,7 +59,7 @@ export function setPositionImg(position: Position) {
   }
 }
 
-export function setAbbrevTier(tier: string) {
+export function setTierAbbr(tier: string) {
   switch (tier) {
     case "IRON":
       return "I";

--- a/src/utils/custom.tsx
+++ b/src/utils/custom.tsx
@@ -59,7 +59,7 @@ export function setPositionImg(position: Position) {
   }
 }
 
-export function setTierAbbr(tier: string) {
+export function checkTierAbbr(tier: string) {
   switch (tier) {
     case "IRON":
       return "I";


### PR DESCRIPTION
## 연관 이슈

#331

<br/>

## 📁 작업 내용
- Profile 컴포넌트 분리 리팩토링

<img width="241" height="287" alt="image" src="https://github.com/user-attachments/assets/8ee2c671-3e1c-41ac-a14f-42037bd46be7" />

<br/>


## 📁 기타 사항

아직 리팩토링 다 끝낸 건 아니고 hook 분리랑 Position 영역 컴포넌트 분리 작업했습니다. 우선 나눠두기만 했는데 `useMoreBoxOutsideClick`나 `useReport` 이거는 다른 데에서도 쓸 수 있는 거라 아예 바깥으로 분리해도 좋을 것 같아요. 일단 Profile 컴포넌트가 기존에 1000줄 넘게.. 너무 길었던지라 하나씩 나누고, 공통 훅 리팩토링도 해볼게요!

<br/>
