### PR TITLE
[Fix] 라이엇 로그인 이후 로그인 상태 유지 및 소켓 초기화 오류 수정

### DIFF
--- a/src/app/join/terms/page.tsx
+++ b/src/app/join/terms/page.tsx
@@ -66,6 +66,10 @@ const Terms = () => {
           puuid,
           isAgree: terms[2],
         });
+        notify({
+          text: ko["join.riot.success"],
+          type: "success",
+        });
         dispatch(clearSignIn());
         router.push("/riot");
       } catch (err) {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -20,7 +20,7 @@ import {
   setUserProfileImg,
 } from "@/redux/slices/userSlice";
 import { theme } from "@/styles/theme";
-import { clearTokens, setId } from "@/utils/storage";
+import { clearTokens } from "@/utils/storage";
 
 const Login = () => {
   const router = useRouter();
@@ -81,16 +81,16 @@ const Login = () => {
       const storage = autoLogin ? localStorage : sessionStorage;
       storage.setItem(STORAGE_KEY.accessToken, accessToken);
       storage.setItem(STORAGE_KEY.refreshToken, refreshToken);
-
-      dispatch(setUserName(response.data.name));
-      dispatch(setUserProfileImg(response.data.profileImage));
-      dispatch(setUserId(response.data.id));
       storage.setItem(STORAGE_KEY.name, response.data.name);
       storage.setItem(
         STORAGE_KEY.profileImg,
         response.data.profileImage.toString()
       );
-      setId(response.data.id, autoLogin);
+      storage.setItem(STORAGE_KEY.userId, response.data.id.toString());
+
+      dispatch(setUserName(response.data.name));
+      dispatch(setUserProfileImg(response.data.profileImage));
+      dispatch(setUserId(response.data.id));
 
       router.push("/");
 

--- a/src/app/riot/callback/page.tsx
+++ b/src/app/riot/callback/page.tsx
@@ -5,10 +5,12 @@ import { useDispatch } from "react-redux";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 
+import { getUnreadUuid, socketLogin } from "@/api";
 import { LoadingSpinner } from "@/components";
 import ko from "@/constants/ko.json";
 import { STORAGE_KEY } from "@/constants/storage";
 import { notify } from "@/hooks";
+import { setUnreadUuid } from "@/redux/slices/chatSlice";
 import {
   setUserId,
   setUserName,
@@ -19,8 +21,8 @@ const RsoCallback = () => {
   const router = useRouter();
   const dispatch = useDispatch();
 
-  useEffect(
-    () => {
+  useEffect(() => {
+    const fetchData = async () => {
       const url = new URL(window.location.href);
       const accessToken = url.searchParams.get("accessToken");
       const refreshToken = url.searchParams.get("refreshToken");
@@ -30,6 +32,7 @@ const RsoCallback = () => {
       const puuid = url.searchParams.get("puuid");
       const state = url.searchParams.get("state");
       const error = url.searchParams.get("error");
+      const autoLogin = sessionStorage.getItem(STORAGE_KEY.autoLogin);
 
       if (error === "signup_disabled") {
         // 소환사명이 없을 경우 오류 처리
@@ -42,23 +45,44 @@ const RsoCallback = () => {
       }
 
       if (accessToken && refreshToken && name && profileImage && id) {
-        // 로그인 완료 처리
-        localStorage.setItem(STORAGE_KEY.accessToken, accessToken);
-        localStorage.setItem(STORAGE_KEY.refreshToken, refreshToken);
+        /* 자동 로그인 체크 여부에 따라 토큰 저장 위치 결정 */
+        const storage = Boolean(autoLogin) ? localStorage : sessionStorage;
+        storage.setItem(STORAGE_KEY.accessToken, accessToken);
+        storage.setItem(STORAGE_KEY.refreshToken, refreshToken);
+        storage.setItem(STORAGE_KEY.name, name);
+        storage.setItem(STORAGE_KEY.profileImg, profileImage);
+        storage.setItem(STORAGE_KEY.userId, id);
+
         dispatch(setUserName(name));
         dispatch(setUserProfileImg(Number(profileImage)));
         dispatch(setUserId(Number(id)));
+
         router.push("/");
+        sessionStorage.removeItem(STORAGE_KEY.autoLogin);
+
+        socketLogin();
+
+        /* 소켓 로그인 */
+        const data = await getUnreadUuid();
+        if (data.status === 200) {
+          // 실시간 안읽은 채팅방 수 가져오기 위함
+          dispatch(setUnreadUuid(data.data.data));
+          // 새로고침시 채팅방 수 가져오기 위함
+          sessionStorage.setItem(
+            STORAGE_KEY.unreadChatUuids,
+            JSON.stringify(data.data.data)
+          );
+        }
       } else if (puuid) {
         // 회원가입 페이지로 이동
         router.push(`/join/terms?puuid=${puuid}&state=${state}`);
       } else {
         console.error("유효하지 않은 응답입니다.");
       }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
+    };
+
+    fetchData();
+  }, []);
 
   return (
     <LoadingContainer>

--- a/src/app/riot/page.tsx
+++ b/src/app/riot/page.tsx
@@ -36,6 +36,7 @@ const RiotLogin = () => {
   const handleLogin = async () => {
     // 라이엇 로그인으로 이동
     const csrfToken = crypto.lib.WordArray.random(16).toString();
+    sessionStorage.setItem(STORAGE_KEY.autoLogin, autoLogin.toString());
     sessionStorage.setItem(STORAGE_KEY.csrfToken, csrfToken);
 
     const redirect = process.env.NEXT_PUBLIC_RIOT_REDIRECT_AFTER_LOGIN!;

--- a/src/constants/ko.json
+++ b/src/constants/ko.json
@@ -22,6 +22,7 @@
   "error.friend.MEMBER_401": "해당 사용자를 찾을 수 없습니다.",
   "error.friend.MEMBER_402": "탈퇴한 사용자입니다.",
   "feedback.success": "GAMEGOO를 위한 소중한 피드백 감사합니다:)",
+  "join.riot.success": "회원가입이 성공적으로 완료되었습니다.",
   "join.riot.error.retry": "회원가입에 실패했습니다. 다시 시도해주세요.",
   "join.riot.error": "Riot 로그인으로 회원가입을 진행해주세요.",
   "login.expired": "세션이 만료되었습니다. 다시 로그인 해주세요.",

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -11,4 +11,5 @@ export const STORAGE_KEY = {
   unreadChatUuids: "@GAMEGOO_UNREAD_CHAT_UUIDS",
   csrfToken: "@GAMEGOO_CSRF_TOKEN",
   logout: "@GAMEGOO_LOGOUT",
+  autoLogin: "@GAMEGOO_AUTO_LOGIN"
 };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,13 +1,5 @@
 import { STORAGE_KEY } from "@/constants/storage";
 
-export const setId = (id: number, autoLogin: boolean) => {
-  if (typeof window !== "undefined") {
-    const storage = autoLogin ? localStorage : sessionStorage;
-    storage.setItem(STORAGE_KEY.userId, id.toString());
-  }
-  return null;
-};
-
 /* 토큰 사용 */
 export const getAccessToken = () => {
   if (typeof window !== "undefined") {


### PR DESCRIPTION
## 연관 이슈

close #306

<br/>

## 📁 작업 내용

라이엇 로그인 이후 로그인 상태 유지 및 소켓 초기화 오류 수정
- 기존에 name이랑 profileImage는 스토리지에 저장이 안되고 redux에만 저장이 되어 새로고침 시에 날라간 것 같아요. 관련 부분 다시 수정하고 자동 로그인 설정 반영, 로그인 후 소켓 로그인 API 연결까지 완료했습니다.
- 먼저 반영하고 확인해볼게요!
<br/>
