### PR TITLE
[Feat] 신고 횟수 제한 모달 추가

### DIFF
--- a/src/components/readBoard/ReportModal.tsx
+++ b/src/components/readBoard/ReportModal.tsx
@@ -4,7 +4,13 @@ import { useRouter } from "next/navigation";
 import styled from "styled-components";
 
 import { reportMember } from "@/api";
-import { Button, Checkbox, FormModal, Input } from "@/components/common";
+import {
+  Button,
+  Checkbox,
+  ConfirmModal,
+  FormModal,
+  Input,
+} from "@/components/common";
 import { REPORT_REASON } from "@/constants/report";
 import { setCloseModal } from "@/redux/slices/modalSlice";
 import { theme } from "@/styles/theme";
@@ -24,6 +30,7 @@ const ReportModal = ({
   const dispatch = useDispatch();
   const isUser = useSelector((state: RootState) => state.user);
   const [showAlert, setShowAlert] = useState(false);
+  const [isError, setIsError] = useState(false);
   const [alertProps, setAlertProps] = useState<AlertProps>({
     icon: "",
     width: 0,
@@ -70,6 +77,7 @@ const ReportModal = ({
   const handleModalClose = () => {
     setCheckedItems([]);
     setReportDetail("");
+    setIsError(false);
     dispatch(setCloseModal());
   };
 
@@ -97,7 +105,10 @@ const ReportModal = ({
     try {
       await reportMember(params);
       await handleModalClose();
-    } catch (error) {
+    } catch (error: any) {
+      if (error.response.data.code === "REPORT_404") {
+        setIsError(true);
+      }
       console.error(error);
     }
   };
@@ -156,6 +167,15 @@ const ReportModal = ({
           </ReportButton>
         </div>
       </FormModal>
+      {isError && (
+        <ConfirmModal
+          width="540px"
+          primaryButtonText="확인"
+          onPrimaryClick={() => setIsError(false)}
+        >
+          같은 유저에 대한 신고는 하루에 한 번만 가능합니다.
+        </ConfirmModal>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## 연관 이슈

close #308 

<br/>

## 📁 작업 내용

신고 횟수 에러일 경우 모달을 띄우게 했습니다.

<br/>

## 🖥 구현 결과 (선택)


<img width="1320" height="793" alt="스크린샷 2025-07-14 오후 10 07 59" src="https://github.com/user-attachments/assets/590e0706-a95d-466c-ae1a-e6746ae43cc6" />

<br/>

## ✔ 리뷰 요구사항

조건을 `error.response.data.code === "REPORT_404"`로 설정했는데 이렇게 백엔드에서 설정해주는 에러 코드로 작업하면 될까요?

<br/>

