### PR TITLE
[Chore] git hook으로 precommit 설정 (이슈 번호 태그 자동화)

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# 현재 브랜치명 가져오기
+BRANCH_NAME=$(git branch --show-current)
+
+# 브랜치명에서 이슈번호 추출 (예: chore/#123 -> 123)
+ISSUE_NUMBER=$(echo "$BRANCH_NAME" | grep -oE '#[0-9]+' | sed 's/#//')
+
+# 이슈번호가 있는 경우만 처리
+if [ -n "$ISSUE_NUMBER" ]; then
+    # 커밋 메시지 파일 경로
+    COMMIT_MSG_FILE=$1
+    
+    # 현재 커밋 메시지 읽기
+    COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+    
+    # 이미 이슈번호가 포함되어 있는지 확인
+    if [[ ! "$COMMIT_MSG" =~ \(#[0-9]+\) ]]; then
+        # 커밋 메시지 패턴 확인 (예: feat:, fix:, chore: 등)
+        if [[ "$COMMIT_MSG" =~ ^([a-zA-Z]+):\ (.+)$ ]]; then
+            TYPE="${BASH_REMATCH[1]}"
+            MESSAGE="${BASH_REMATCH[2]}"
+            
+            # 새로운 커밋 메시지 생성
+            NEW_COMMIT_MSG="${TYPE}(#${ISSUE_NUMBER}): ${MESSAGE}"
+            
+            # 커밋 메시지 파일에 새 메시지 쓰기
+            echo "$NEW_COMMIT_MSG" > "$COMMIT_MSG_FILE"
+        fi
+    fi
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "gamegoo",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@emailjs/browser": "^4.4.1",
         "@next/third-parties": "^15.1.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "next lint",
     "generate": "tsx scripts/generate-api.ts && eslint --fix src/@generated && prettier --write src/@generated",
-    "format": "eslint --fix src && prettier --write ."
+    "format": "eslint --fix src && prettier --write .",
+    "postinstall": "git config core.hooksPath .githooks"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
## 연관 이슈

close #338 

<br/>

## 📁 작업 내용

설정하려는게 복잡하지 않아서 husky 대신 git hooks 기능을 사용했어요

git hooks 기능(참고: https://git-scm.com/book/ms/v2/Customizing-Git-Git-Hooks) 추가
원래는 .git/hooks에 만들어 개인 맞춤 hook을 사용하기도 하는데 다들 쓰고 있진 않으신 것 같아서 공용으로 쓰려고 .githooks 파일을 만들고 환경변수를 gitconfig로 수정했어요 (참고: https://git-scm.com/docs/githooks)

package script에 postinstall에 위에서 언급했던 환경변수 바꾸는 명령어를 실행하게 해서
`npm install`을 하면 자동으로 세팅되게 만들었어요

<br/>

## 🖥 구현 결과 (선택)

<img width="562" height="175" alt="스크린샷 2025-07-16 오전 11 29 57" src="https://github.com/user-attachments/assets/006e01c7-63d5-48e7-9b2d-211e8e9830c8" />

<img width="569" height="164" alt="스크린샷 2025-07-16 오전 11 30 44" src="https://github.com/user-attachments/assets/1959805e-c2eb-4aff-a79c-08c599eabbd7" />

<br/>

## 📁 기타 사항

앞으로도 커밋할 때 불편한 점들이 있으면 자동화하면 좋을 것 같아요! lint 관련해서도 자동화할 수도 있어요

<br/>
