### PR TITLE
[Fix] 라이엇 로그인 시 소켓 로그인 오류 수정

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -80,7 +80,7 @@ AuthAxios.interceptors.response.use(
         // 토큰 재발급 실패 시 처리
         console.error("토큰 재발급 실패:", reissueError);
         clearTokens(); // 저장된 토큰 삭제
-        window.location.replace("/login"); // 로그인 페이지로 이동
+        window.location.replace("/riot"); // 로그인 페이지로 이동
       }
     }
     return Promise.reject(error);

--- a/src/app/riot/callback/page.tsx
+++ b/src/app/riot/callback/page.tsx
@@ -16,6 +16,7 @@ import {
   setUserName,
   setUserProfileImg,
 } from "@/redux/slices/userSlice";
+import { connectSocket, socket } from "@/socket";
 
 const RsoCallback = () => {
   const router = useRouter();
@@ -60,9 +61,23 @@ const RsoCallback = () => {
         router.push("/");
         sessionStorage.removeItem(STORAGE_KEY.autoLogin);
 
-        socketLogin();
-
         /* 소켓 로그인 */
+        // 소켓이 없다면 연결
+        if (!socket) {
+          connectSocket();
+        }
+
+        const onSocketConnectedAndLogin = () => {
+          socketLogin();
+          socket?.off("connect", onSocketConnectedAndLogin);
+        };
+
+        if (socket?.connected) {
+          socketLogin();
+        } else {
+          socket?.on("connect", onSocketConnectedAndLogin);
+        }
+
         const data = await getUnreadUuid();
         if (data.status === 200) {
           // 실시간 안읽은 채팅방 수 가져오기 위함
@@ -80,7 +95,6 @@ const RsoCallback = () => {
         console.error("유효하지 않은 응답입니다.");
       }
     };
-
     fetchData();
   }, []);
 


### PR DESCRIPTION
## 연관 이슈

close #345

<br/>

## 📁 작업 내용
> 기존 문제
- **라이엇 로그인 후** 페이지가 새로고침되면서 connectSocket()이 재실행되고 **socketId가 바뀌는 반면**, **그 전에 저장된 socketId**를 가지고 socketLogin()을 **호출**해서 불일치 오류가 발생하였다.
- 일반 자체 로그인은 SPA 흐름이라 새로고침이 발생하지 않아 socketId가 동일하게 유지되지만, **라이엇 로그인은 외부 인증 후 리다이렉트되면서 브라우저가 완전히 reload**되기 때문에 **소켓 연결도 새로** 되며 socket.id가 갱신된 것!

> 수정 방안
- 따라서 connectSocket()에서 소켓 연결 완료 (socket.on("connect")) 후에만 socketLogin()을 호출하도록 수정했다.

```
      const onSocketConnectedAndLogin = () => {
        socketLogin();
        socket?.off("connect", onSocketConnectedAndLogin); // 중복 방지
      };

      if (socket?.connected) {
        socketLogin();
      } else {
        // 소켓 연결되면 로그인 실행
        socket?.on("connect", onSocketConnectedAndLogin);
      }
```
<br/>

## 📁 기타 사항

- 참고로, RSO(라이엇 로그인)는 localhost에서의 요청을 거부하고 있어 배포 주소에서밖에 테스트가 어렵습니다! 카카오 로그인과는 조금 다른 부분이 있어 테스트가 불편해요😢 배포 반영 후에 결과 확인해보도록 하겠습니다! @42sungwook @hani0903 

> 추가
- 성공적으로 반영되었습니다!
<img width="780" height="190" alt="image" src="https://github.com/user-attachments/assets/9bebeaa0-b1b5-46d9-b6d6-75385b1dbbe8" />

<br/>
