### PR TITLE
[Fix] 알림에서 프로필 페이지 접근 에러

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,12 @@ export function middleware(request: NextRequest) {
   const token = request.headers.get("Authorization")?.split(" ")[1];
   const { pathname } = request.nextUrl;
 
+  // /member/profile 경로를 /user로 리다이렉트
+  if (pathname.startsWith("/member/profile/")) {
+    const userId = pathname.replace("/member/profile/", "");
+    return NextResponse.redirect(new URL(`/user/${userId}`, request.url));
+  }
+
   // 로그인하지 않은 상태
   if (
     token &&
@@ -32,5 +38,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/match/:path*", "/matching/:path*"],
+  matcher: ["/match/:path*", "/matching/:path*", "/member/:path*"],
 };


### PR DESCRIPTION
## 연관 이슈

close #376 

<br/>

## 📁 작업 내용

현재 프로필 페이지 주소가 `/user/{userId}`인데 기존에는 `/member/profile/{memberId}`였던 것 같아요. 백엔드에서 주는 pageUrl 주소와 현재 주소가 일치하지 않아 생긴 문제였습니다.
`/member/profile` => `/user` 로 리다이렉트되도록 middleware 설정에 추가했어요.

<br/>

